### PR TITLE
feat: jwt 이용한 인증, 인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ repositories {
 }
 
 dependencies {
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kefa/KefaApplication.java
+++ b/src/main/java/com/kefa/KefaApplication.java
@@ -2,7 +2,9 @@ package com.kefa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class KefaApplication {
 

--- a/src/main/java/com/kefa/domain/entity/Account.java
+++ b/src/main/java/com/kefa/domain/entity/Account.java
@@ -1,0 +1,43 @@
+package com.kefa.domain.entity;
+
+import com.kefa.domain.type.Role;
+import com.kefa.domain.type.SubscriptionType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "account")
+@EntityListeners(AuditingEntityListener.class)
+public class Account {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String email;
+
+    private String name;
+
+    private String password;
+
+    private SubscriptionType subscription_type;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/kefa/domain/type/Role.java
+++ b/src/main/java/com/kefa/domain/type/Role.java
@@ -1,0 +1,16 @@
+package com.kefa.domain.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    ADMIN("관리자"),
+    EXPERT("전문가"),
+    STAFF("직원"),
+    ACCOUNT("회원");
+
+    private final String role;
+}

--- a/src/main/java/com/kefa/domain/type/SubscriptionType.java
+++ b/src/main/java/com/kefa/domain/type/SubscriptionType.java
@@ -1,0 +1,15 @@
+package com.kefa.domain.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SubscriptionType {
+
+    FREE("무료"),
+    PREMIUM("프리미엄"),
+    CONCIERGE("컨시어지");
+
+    private final String type;
+}

--- a/src/main/java/com/kefa/infrastructure/repository/AccountRepository.java
+++ b/src/main/java/com/kefa/infrastructure/repository/AccountRepository.java
@@ -1,0 +1,10 @@
+package com.kefa.infrastructure.repository;
+
+import com.kefa.domain.entity.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+}

--- a/src/main/java/com/kefa/infrastructure/security/auth/CustomUserDetails.java
+++ b/src/main/java/com/kefa/infrastructure/security/auth/CustomUserDetails.java
@@ -1,0 +1,71 @@
+package com.kefa.infrastructure.security.auth;
+
+import com.kefa.domain.entity.Account;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+    private final Long id;
+    private final String name;
+    private final String email;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+    private final String subscriptionType;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public CustomUserDetails(Account account) {
+        this.id = account.getId();
+        this.name = account.getName();
+        this.email = account.getEmail();
+        this.password = account.getPassword();
+        this.subscriptionType = account.getSubscription_type().toString();
+        this.authorities = Collections.singleton(
+            new SimpleGrantedAuthority("ROLE_" + account.getRole().name())
+        );
+        this.createdAt = account.getCreatedAt();
+        this.updatedAt = account.getUpdatedAt();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/kefa/infrastructure/security/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/kefa/infrastructure/security/auth/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package com.kefa.infrastructure.security.auth;
+
+import com.kefa.domain.entity.Account;
+import com.kefa.infrastructure.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        Account account = accountRepository.findById(Long.parseLong(id))
+            .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + id));
+
+        return new CustomUserDetails(account);
+    }
+}

--- a/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.kefa.security.config;
+package com.kefa.infrastructure.security.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.kefa.infrastructure.security.config;
 
+import com.kefa.infrastructure.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,11 +11,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -32,6 +36,7 @@ public class SecurityConfig {
                 .requestMatchers("/auth/**", "/public/**").permitAll()
                 .anyRequest().authenticated()
             )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .formLogin(AbstractHttpConfigurer::disable)
             .logout(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable);

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package com.kefa.infrastructure.security.jwt;
+
+import com.kefa.domain.type.Role;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = getTokenFromRequest(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+
+            Long id = jwtTokenProvider.getId(token);
+            Role role = jwtTokenProvider.getRole(token);
+            Collection<GrantedAuthority> authorities =
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role.name()));
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                String.valueOf(id),
+                null,
+                authorities
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtProperties.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.kefa.infrastructure.security.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class JwtProperties {
+
+    @Value("${jwt.key}")
+    private String key;
+    @Value("${jwt.access-expiration-time}")
+    private long accessExpirationTime;
+    @Value("${jwt.refresh-expiration-time}")
+    private long refreshExpirationTime;
+
+}

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtToken.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtToken.java
@@ -1,0 +1,13 @@
+package com.kefa.infrastructure.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtToken {
+
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,87 @@
+package com.kefa.infrastructure.security.jwt;
+
+import com.kefa.domain.type.Role;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        byte[] keyByte = Decoders.BASE64.decode(jwtProperties.getKey());
+        this.key = Keys.hmacShaKeyFor(keyByte);
+    }
+
+    private String createToken(Long id, Role role, long expirationTime) {
+        Date nowDate = new Date();
+        Date expirationDate = new Date(nowDate.getTime() + expirationTime);
+
+        return Jwts.builder()
+            .subject(String.valueOf(id))
+            .claim("role", role.name())
+            .issuedAt(nowDate)
+            .expiration(expirationDate)
+            .signWith(key)
+            .compact();
+    }
+
+    public String createAccessToken(Long id, Role role) {
+        return createToken(id, role, jwtProperties.getAccessExpirationTime());
+    }
+
+    public String createRefreshToken(Long id, Role role) {
+        return createToken(id, role, jwtProperties.getRefreshExpirationTime());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (SecurityException | io.jsonwebtoken.security.SecurityException e) {
+            log.info("유효하지 않은 JWT 서명입니다.: {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.info("잘못된 JWT 토큰입니다.: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 비어있습니다.: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+    }
+
+    public Long getId(String token) {
+        String subject = getClaims(token).getSubject();
+        return Long.valueOf(subject);
+    }
+
+    public Role getRole(String token) {
+        return Role.valueOf(getClaims(token).get("role", String.class));
+    }
+}

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtTokenProvider.java
@@ -56,16 +56,20 @@ public class JwtTokenProvider {
             return true;
         } catch (SecurityException | io.jsonwebtoken.security.SecurityException e) {
             log.info("유효하지 않은 JWT 서명입니다.: {}", e.getMessage());
+            throw e;
         } catch (MalformedJwtException e) {
             log.info("잘못된 JWT 토큰입니다.: {}", e.getMessage());
+            throw e;
         } catch (ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다.: {}", e.getMessage());
+            throw e;
         } catch (UnsupportedJwtException e) {
             log.info("지원되지 않는 JWT 토큰입니다.: {}", e.getMessage());
+            throw e;
         } catch (IllegalArgumentException e) {
             log.info("JWT 토큰이 비어있습니다.: {}", e.getMessage());
+            throw e;
         }
-        return false;
     }
 
     private Claims getClaims(String token) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,8 @@ spring:
     show-sql: true
     properties:
       hibernate:
+
+jwt:
+  key: ${JWT_KEY}
+  access-expiration-time: ${JWT_ACCESS_EXPIRATION_TIME}
+  refresh-expiration-time: ${JWT_REFRESH_EXPIRATION_TIME}

--- a/src/test/java/com/kefa/KefaApplicationTests.java
+++ b/src/test/java/com/kefa/KefaApplicationTests.java
@@ -2,7 +2,9 @@ package com.kefa;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class KefaApplicationTests {
 

--- a/src/test/java/com/kefa/KefaApplicationTests.java
+++ b/src/test/java/com/kefa/KefaApplicationTests.java
@@ -2,10 +2,18 @@ package com.kefa;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.TestPropertySource;
 
-@ActiveProfiles("test")
 @SpringBootTest
+@MockBean(JpaMetamodelMappingContext.class)
+@TestPropertySource(properties = {
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.datasource.url=jdbc:h2:mem:testdb",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+})
 class KefaApplicationTests {
 
     @Test

--- a/src/test/java/com/kefa/config/SecurityConfigTest.java
+++ b/src/test/java/com/kefa/config/SecurityConfigTest.java
@@ -1,6 +1,6 @@
 package com.kefa.config;
 
-import com.kefa.security.config.SecurityConfig;
+import com.kefa.infrastructure.security.config.SecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
@@ -1,10 +1,12 @@
 package com.kefa.infrastructure.security.config;
 
+import com.kefa.infrastructure.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,9 +20,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SecurityConfig.class)
-@AutoConfigureMockMvc
+@MockBean(JpaMetamodelMappingContext.class)
 public class SecurityConfigTest {
 
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
     @Autowired
     private MockMvc mockMvc;
 

--- a/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
@@ -1,6 +1,5 @@
-package com.kefa.config;
+package com.kefa.infrastructure.security.config;
 
-import com.kefa.infrastructure.security.config.SecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/kefa/infrastructure/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/jwt/JwtTokenProviderTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -17,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
 public class JwtTokenProviderTest {
 
     @MockBean

--- a/src/test/java/com/kefa/infrastructure/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/jwt/JwtTokenProviderTest.java
@@ -1,6 +1,7 @@
 package com.kefa.infrastructure.security.jwt;
 
 import com.kefa.domain.type.Role;
+import com.kefa.infrastructure.security.auth.CustomUserDetailsService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,13 +9,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
+@SpringBootTest
 public class JwtTokenProviderTest {
+
+    @MockBean
+    private CustomUserDetailsService customUserDetailsService;
 
     private JwtTokenProvider jwtTokenProvider;
     private JwtTokenProvider expiredTokenProvider;

--- a/src/test/java/com/kefa/infrastructure/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/jwt/JwtTokenProviderTest.java
@@ -6,13 +6,14 @@ import io.jsonwebtoken.MalformedJwtException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class JwtTokenProviderTest {
 
     private JwtTokenProvider jwtTokenProvider;

--- a/src/test/java/com/kefa/infrastructure/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,197 @@
+package com.kefa.infrastructure.security.jwt;
+
+import com.kefa.domain.type.Role;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+public class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+    private JwtTokenProvider expiredTokenProvider;
+    private String expiredToken;
+
+    @BeforeEach
+    void setUp() throws InterruptedException {
+        // 일반 토큰 Provider
+        JwtProperties properties = new JwtProperties();
+        ReflectionTestUtils.setField(properties, "key", "testSecretKeytestSecretKeytestSecretKeytestSecretKey");
+        ReflectionTestUtils.setField(properties, "accessExpirationTime", 3600L);
+        ReflectionTestUtils.setField(properties, "refreshExpirationTime", 72000L);
+        jwtTokenProvider = new JwtTokenProvider(properties);
+        jwtTokenProvider.init();
+
+        // 만료 토큰 Provider
+        JwtProperties expiredProperties = new JwtProperties();
+        ReflectionTestUtils.setField(expiredProperties, "key", "testSecretKeytestSecretKeytestSecretKeytestSecretKey");
+        ReflectionTestUtils.setField(expiredProperties, "accessExpirationTime", 1L); // 1ms
+        ReflectionTestUtils.setField(expiredProperties, "refreshExpirationTime", 1L);
+        expiredTokenProvider = new JwtTokenProvider(expiredProperties);
+        expiredTokenProvider.init();
+
+        // 만료된 토큰 생성
+        expiredToken = expiredTokenProvider.createAccessToken(1L, Role.ACCOUNT);
+        Thread.sleep(10); // 토큰 만료를 위해 대기
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 생성 성공 테스트")
+    void createAccessTokenSuccess() {
+        // given
+        Long id = 1L;
+        Role role = Role.ACCOUNT;
+
+        // when
+        String token = jwtTokenProvider.createAccessToken(id, role);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+        assertThat(jwtTokenProvider.getId(token)).isEqualTo(id);
+        assertThat(jwtTokenProvider.getRole(token)).isEqualTo(role);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 생성 성공 테스트")
+    void createRefreshTokenSuccess() {
+        // given
+        Long id = 1L;
+        Role role = Role.ACCOUNT;
+
+        // when
+        String token = jwtTokenProvider.createRefreshToken(id, role);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+        assertThat(jwtTokenProvider.getId(token)).isEqualTo(id);
+        assertThat(jwtTokenProvider.getRole(token)).isEqualTo(role);
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 토큰 생성 성공 테스트")
+    void createTokenWithAdminRoleSuccess() {
+        // given
+        Long id = 1L;
+        Role role = Role.ADMIN;
+
+        // when
+        String token = jwtTokenProvider.createAccessToken(id, role);
+
+        // then
+        assertThat(jwtTokenProvider.getRole(token)).isEqualTo(Role.ADMIN);
+        assertThat(jwtTokenProvider.getRole(token).getRole()).isEqualTo("관리자");
+    }
+
+    @Test
+    @DisplayName("전문가 권한으로 토큰 생성 성공 테스트")
+    void createTokenWithExpertRoleSuccess() {
+        // given
+        Long id = 1L;
+        Role role = Role.EXPERT;
+
+        // when
+        String token = jwtTokenProvider.createAccessToken(id, role);
+
+        // then
+        assertThat(jwtTokenProvider.getRole(token)).isEqualTo(Role.EXPERT);
+        assertThat(jwtTokenProvider.getRole(token).getRole()).isEqualTo("전문가");
+    }
+
+    @Test
+    @DisplayName("직원 권한으로 토큰 생성 성공 테스트")
+    void createTokenWithStaffRoleSuccess() {
+        // given
+        Long id = 1L;
+        Role role = Role.STAFF;
+
+        // when
+        String token = jwtTokenProvider.createAccessToken(id, role);
+
+        // then
+        assertThat(jwtTokenProvider.getRole(token)).isEqualTo(Role.STAFF);
+        assertThat(jwtTokenProvider.getRole(token).getRole()).isEqualTo("직원");
+    }
+
+    @Test
+    @DisplayName("유효한 토큰 검증 성공 테스트")
+    void validateTokenSuccess() {
+        // given
+        String token = jwtTokenProvider.createAccessToken(1L, Role.ACCOUNT);
+
+        // when
+        boolean isValid = jwtTokenProvider.validateToken(token);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰 검증 실패 테스트")
+    void validateTokenFailWithInvalidToken() {
+        // given
+        String testToken = "this is token";
+
+        // when & then
+        assertThrows(MalformedJwtException.class, () ->
+            jwtTokenProvider.validateToken(testToken)
+        );
+    }
+
+    @Test
+    @DisplayName("토큰에서 ID 추출 성공 테스트")
+    void getIdFromTokenSuccess() {
+        // given
+        Long id = 1L;
+        String token = jwtTokenProvider.createAccessToken(id, Role.ACCOUNT);
+
+        // when
+        Long getId = jwtTokenProvider.getId(token);
+
+        // then
+        assertThat(getId).isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("토큰에서 Role 추출 성공 테스트")
+    void getRoleSuccess() {
+        // given
+        Role role = Role.ACCOUNT;
+        String token = jwtTokenProvider.createAccessToken(1L, role);
+
+        // when
+        Role getRole = jwtTokenProvider.getRole(token);
+
+        // then
+        assertThat(getRole).isEqualTo(role);
+        assertThat(getRole.getRole()).isEqualTo("회원");
+    }
+
+    @Test
+    @DisplayName("만료된 토큰 검증 실패 테스트")
+    void validateTokenFailWithExpiredToken() {
+
+        // when & then
+        assertThrows(ExpiredJwtException.class, () ->
+            jwtTokenProvider.validateToken(expiredToken)
+        );
+    }
+
+    @Test
+    @DisplayName("만료된 토큰에서 정보 추출 시 예외 발생 테스트")
+    void getInfoFromExpiredTokenThrowsException() {
+
+        // when & then
+        assertThrows(ExpiredJwtException.class, () -> jwtTokenProvider.getId(expiredToken));
+        assertThrows(ExpiredJwtException.class, () -> jwtTokenProvider.getRole(expiredToken));
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: kefa
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+jwt:
+  key: testSecretKeytestSecretKeytestSecretKeytestSecretKeytestSecretKeytestSecretKey
+  access-expiration-time: 3600000
+  refresh-expiration-time: 1209600000


### PR DESCRIPTION
## 📎 Issue
  <!-- 관련 이슈 번호를 적어주세요 -->
Close #16 

## 💫 작업 내용
  <!-- 작업한 내용을 설명해주세요 -->
- 구현 내용 요약
jwt 설정
jwt 발급, 검증, 추출
jwt 인증 인가를 위한 필터
UserDetails와 Service 구현
단위 테스트를 위해 Account Entity 및 Repository 임시 구현
단일 책임을 위해 설정 클래스, 토큰을 담는 DTO 클래스, Jwt 생성, 추출, 검증하는 Provider 클래스로 나눔

- 변경사항 설명
예외 전역 처리를 위해 따로 Jwt 처리만을 위한 핸들러는 구현 X
Jwt 검증시 예외를 던지는 것으로 변경

## ✅ 체크리스트
- [X] 추가 및 변경 사항에 대한 테스트를 진행했습니다.
- [X] 불필요한 코드가 없습니다.
