### PR TITLE
feat: 회원가입 기능

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,19 @@ pipeline {
                                 string(credentialsId: 'JENKINS_AGENT_PORT', variable: 'JENKINS_AGENT_PORT'),
                                 string(credentialsId: 'TZ', variable: 'TZ'),
                                 string(credentialsId: 'SMEE_URL', variable: 'SMEE_URL'),
-                                string(credentialsId: 'SMEE_TARGET', variable: 'SMEE_TARGET')
+                                string(credentialsId: 'SMEE_TARGET', variable: 'SMEE_TARGET'),
+                                string(credentialsId: 'JWT_KEY', variable: 'JWT_KEY'),
+                                string(credentialsId: 'JWT_ACCESS_EXPIRATION_TIME', variable: 'JWT_ACCESS_EXPIRATION_TIME'),
+                                string(credentialsId: 'JWT_REFRESH_EXPIRATION_TIME', variable: 'JWT_REFRESH_EXPIRATION_TIME'),
+                                string(credentialsId: 'MAIL_USERNAME', variable: 'MAIL_USERNAME'),
+                                string(credentialsId: 'MAIL_PASSWORD', variable: 'MAIL_PASSWORD'),
+                                string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'),
+                                string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'),
+                                string(credentialsId: 'KAKAO_CLIENT_ID', variable: 'KAKAO_CLIENT_ID'),
+                                string(credentialsId: 'KAKAO_CLIENT_SECRET', variable: 'KAKAO_CLIENT_SECRET'),
+                                string(credentialsId: 'OAUTH2_MAIN_PAGE_URI', variable: 'OAUTH2_MAIN_PAGE_URI'),
+                                string(credentialsId: 'CIPHER_SECRET_KEY', variable: 'CIPHER_SECRET_KEY'),
+                                string(credentialsId: 'CIPHER_IV', variable: 'CIPHER_IV')
                             ]) {
                                 sh '''
                                     echo "DB_HOST=${DB_HOST}" > .env
@@ -77,6 +89,18 @@ pipeline {
                                     echo "TZ=${TZ}" >> .env
                                     echo "SMEE_URL=${SMEE_URL}" >> .env
                                     echo "SMEE_TARGET=${SMEE_TARGET}" >> .env
+                                    echo "JWT_KEY=${JWT_KEY}" >> .env
+                                    echo "JWT_ACCESS_EXPIRATION_TIME=${JWT_ACCESS_EXPIRATION_TIME}" >> .env
+                                    echo "JWT_REFRESH_EXPIRATION_TIME=${JWT_REFRESH_EXPIRATION_TIME}" >> .env
+                                    echo "MAIL_USERNAME=${MAIL_USERNAME}" >> .env
+                                    echo "MAIL_PASSWORD=${MAIL_PASSWORD}" >> .env
+                                    echo "GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}" >> .env
+                                    echo "GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}" >> .env
+                                    echo "KAKAO_CLIENT_ID=${KAKAO_CLIENT_ID}" >> .env
+                                    echo "KAKAO_CLIENT_SECRET=${KAKAO_CLIENT_SECRET}" >> .env
+                                    echo "OAUTH2_MAIN_PAGE_URI=${OAUTH2_MAIN_PAGE_URI}" >> .env
+                                    echo "CIPHER_SECRET_KEY=${CIPHER_SECRET_KEY}" >> .env
+                                    echo "CIPHER_IV=${CIPHER_IV}" >> .env
                                 '''
                             }
                         }

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testRuntimeOnly 'com.h2database:h2'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kefa/api/controller/AccountController.java
+++ b/src/main/java/com/kefa/api/controller/AccountController.java
@@ -1,0 +1,26 @@
+package com.kefa.api.controller;
+
+import com.kefa.api.dto.request.AccountSignupRequestDto;
+import com.kefa.api.dto.response.AccountSignupResponseDto;
+import com.kefa.application.service.AccountService;
+import com.kefa.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @PostMapping("/auth/signup")
+    public ApiResponse<AccountSignupResponseDto> addAccount(@RequestBody @Valid AccountSignupRequestDto accountSignupRequestDto) {
+
+        return ApiResponse.success(accountService.signup(accountSignupRequestDto));
+
+    }
+
+}

--- a/src/main/java/com/kefa/api/dto/request/AccountSignupRequestDto.java
+++ b/src/main/java/com/kefa/api/dto/request/AccountSignupRequestDto.java
@@ -1,0 +1,46 @@
+package com.kefa.api.dto.request;
+
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.type.LoginType;
+import com.kefa.domain.type.Role;
+import com.kefa.domain.type.SubscriptionType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccountSignupRequestDto {
+
+    @NotBlank(message = "이름은 필수입니다")
+    private String name;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+        message = "비밀번호는 8자 이상, 영문, 숫자, 특수문자를 포함해야 합니다")
+    private String password;
+
+    public Account toEntity(String encodedPassword) {
+        return Account.builder()
+            .name(name)
+            .email(email)
+            .password(encodedPassword)
+            .role(Role.ACCOUNT)
+            .subscriptionType(SubscriptionType.FREE)
+            .loginTypes(Set.of(LoginType.LOCAL))
+            .build();
+    }
+
+}

--- a/src/main/java/com/kefa/api/dto/response/AccountSignupResponseDto.java
+++ b/src/main/java/com/kefa/api/dto/response/AccountSignupResponseDto.java
@@ -1,0 +1,33 @@
+package com.kefa.api.dto.response;
+
+import com.kefa.domain.entity.Account;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AccountSignupResponseDto {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String role;
+    private String subscriptionType;
+    private LocalDateTime createdAt;
+
+    public static AccountSignupResponseDto from(Account account) {
+        return AccountSignupResponseDto.builder()
+            .id(account.getId())
+            .name(account.getName())
+            .email(account.getEmail())
+            .role(account.getRole().getRole())
+            .subscriptionType(account.getSubscriptionType().getType())
+            .createdAt(account.getCreatedAt())
+            .build();
+    }
+
+}

--- a/src/main/java/com/kefa/application/service/AccountService.java
+++ b/src/main/java/com/kefa/application/service/AccountService.java
@@ -1,0 +1,21 @@
+package com.kefa.application.service;
+
+import com.kefa.api.dto.request.AccountSignupRequestDto;
+import com.kefa.api.dto.response.AccountSignupResponseDto;
+import com.kefa.application.usecase.AuthenticationUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AuthenticationUseCase authenticationUseCase;
+
+    public AccountSignupResponseDto signup(AccountSignupRequestDto request) {
+
+        return authenticationUseCase.signup(request);
+
+    }
+
+}

--- a/src/main/java/com/kefa/application/service/AccountService.java
+++ b/src/main/java/com/kefa/application/service/AccountService.java
@@ -3,18 +3,25 @@ package com.kefa.application.service;
 import com.kefa.api.dto.request.AccountSignupRequestDto;
 import com.kefa.api.dto.response.AccountSignupResponseDto;
 import com.kefa.application.usecase.AuthenticationUseCase;
+import com.kefa.application.usecase.EmailVerificationUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AccountService {
 
     private final AuthenticationUseCase authenticationUseCase;
+    private final EmailVerificationUseCase emailVerificationUseCase;
 
+    @Transactional
     public AccountSignupResponseDto signup(AccountSignupRequestDto request) {
 
-        return authenticationUseCase.signup(request);
+        AccountSignupResponseDto response = authenticationUseCase.signup(request);
+        emailVerificationUseCase.sendVerificationEmail(request.getEmail());
+
+        return response;
 
     }
 

--- a/src/main/java/com/kefa/application/usecase/AuthenticationUseCase.java
+++ b/src/main/java/com/kefa/application/usecase/AuthenticationUseCase.java
@@ -61,6 +61,7 @@ public class AuthenticationUseCase {
             .name(email.split("@")[0])
             .password(passwordEncoder.encode(UUID.randomUUID().toString()))
             .subscriptionType(SubscriptionType.FREE)
+            .verified(true)
             .role(Role.ACCOUNT)
             .loginTypes(new HashSet<>(Set.of(loginType)))
             .build()

--- a/src/main/java/com/kefa/application/usecase/AuthenticationUseCase.java
+++ b/src/main/java/com/kefa/application/usecase/AuthenticationUseCase.java
@@ -1,0 +1,88 @@
+package com.kefa.application.usecase;
+
+import com.kefa.api.dto.request.AccountSignupRequestDto;
+import com.kefa.api.dto.response.AccountSignupResponseDto;
+import com.kefa.common.exception.AuthenticationException;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.type.LoginType;
+import com.kefa.domain.type.Role;
+import com.kefa.domain.type.SubscriptionType;
+import com.kefa.domain.vo.AccountVO;
+import com.kefa.infrastructure.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthenticationUseCase {
+
+    private final AccountRepository accountRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public AccountSignupResponseDto signup(AccountSignupRequestDto request) {
+
+        validateDuplicateEmail(request.getEmail());
+        Account account = createAccount(request);
+        return AccountSignupResponseDto.from(account);
+
+    }
+
+    public AccountVO authenticateSocialUser(String email, String provider) {
+
+        LoginType loginType = validateAndGetLoginType(provider);
+
+        return AccountVO.from(accountRepository.findByEmail(email).orElseGet(
+            () -> createSocialAccount(email, loginType))
+        );
+
+    }
+
+    private Account createAccount(AccountSignupRequestDto request) {
+
+        return accountRepository.save(
+            request.toEntity(passwordEncoder.encode(request.getPassword())
+            )
+        );
+
+    }
+
+    private Account createSocialAccount(String email, LoginType loginType) {
+
+        return accountRepository.save(Account.builder()
+            .email(email)
+            .name(email.split("@")[0])
+            .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+            .subscriptionType(SubscriptionType.FREE)
+            .role(Role.ACCOUNT)
+            .loginTypes(new HashSet<>(Set.of(loginType)))
+            .build()
+        );
+
+    }
+
+    private LoginType validateAndGetLoginType(String provider) {
+
+        try {
+            return LoginType.valueOf(provider.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new AuthenticationException(ErrorCode.UNSUPPORTED_SOCIAL_PROVIDER);
+        }
+
+    }
+
+    private void validateDuplicateEmail(String email) {
+
+        if (accountRepository.existsByEmail(email)) {
+            throw new AuthenticationException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+    }
+}

--- a/src/main/java/com/kefa/application/usecase/EmailVerificationUseCase.java
+++ b/src/main/java/com/kefa/application/usecase/EmailVerificationUseCase.java
@@ -1,0 +1,42 @@
+package com.kefa.application.usecase;
+
+import com.kefa.common.exception.AuthenticationException;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.domain.entity.Account;
+import com.kefa.infrastructure.mail.EmailSender;
+import com.kefa.infrastructure.repository.AccountRepository;
+import com.kefa.infrastructure.repository.EmailVerificationRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationUseCase {
+
+    private final EmailVerificationRedisRepository emailVerificationRedisRepository;
+    private final EmailSender emailSender;
+    private final AccountRepository accountRepository;
+
+    public void sendVerificationEmail(String email) {
+        String token = UUID.randomUUID().toString();
+        emailVerificationRedisRepository.saveEmailToken(token, email);
+        emailSender.sendVerificationEmail(email, token);
+    }
+
+    @Transactional
+    public void verifyEmail(String token) {
+        String email = emailVerificationRedisRepository.getEmailByToken(token);
+        if (email == null) {
+            throw new AuthenticationException(ErrorCode.INVALID_EMAIL_VERIFICATION_TOKEN);
+        }
+
+        Account account = accountRepository.findByEmail(email)
+            .orElseThrow(() -> new AuthenticationException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        account.verify();
+        emailVerificationRedisRepository.removeEmailToken(token);
+    }
+}

--- a/src/main/java/com/kefa/common/exception/AuthenticationException.java
+++ b/src/main/java/com/kefa/common/exception/AuthenticationException.java
@@ -1,0 +1,10 @@
+package com.kefa.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthenticationException extends CustomException {
+    public AuthenticationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/kefa/common/exception/CipherException.java
+++ b/src/main/java/com/kefa/common/exception/CipherException.java
@@ -1,0 +1,12 @@
+package com.kefa.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CipherException extends CustomException {
+
+    public CipherException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/kefa/common/exception/EmailException.java
+++ b/src/main/java/com/kefa/common/exception/EmailException.java
@@ -1,0 +1,12 @@
+package com.kefa.common.exception;
+
+public class EmailException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public EmailException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/kefa/common/exception/ErrorCode.java
+++ b/src/main/java/com/kefa/common/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     UNSUPPORTED_SOCIAL_PROVIDER(400, "지원하지 않는 소셜 로그인 제공자입니다"),
     ACCOUNT_NOT_FOUND(404, "계정을 찾을 수 없습니다"),
     EMAIL_VERIFICATION_REQUIRED(403, "이메일 인증이 필요합니다"),
+    UNAUTHORIZED(401, "인증이 필요한 서비스입니다"),
+    ACCESS_DENIED(403, "접근 권한이 없습니다"),
 
     // jwt 에러
     INVALID_JWT_SIGNATURE(401, "유효하지 않은 JWT 서명입니다"),
@@ -24,7 +26,9 @@ public enum ErrorCode {
     EMPTY_JWT_TOKEN(401, "JWT 토큰이 비어있습니다"),
 
     // 서버 에러
-    SERVER_ERROR(500, "서버 내부 오류 발생");
+    SERVER_ERROR(500, "서버 내부 오류 발생"),
+    ENCRYPTION_FAILED(500, "데이터 암호화 처리 중 오류가 발생했습니다"),
+    DECRYPTION_FAILED(500, "데이터 복호화 처리 중 오류가 발생했습니다");
 
 
     private final int status;

--- a/src/main/java/com/kefa/common/exception/ErrorCode.java
+++ b/src/main/java/com/kefa/common/exception/ErrorCode.java
@@ -7,6 +7,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    //인증 관련
+    INVALID_ROLE(400, "유효하지 않은 권한입니다."),
+    DUPLICATE_EMAIL(400, "이미 존재하는 이메일입니다"),
+    INVALID_EMAIL_FORMAT(400, "잘못된 이메일 형식입니다"),
+    INVALID_PASSWORD_FORMAT(400, "비밀번호는 8자 이상, 영문/숫자/특수문자를 포함해야 합니다"),
+    UNSUPPORTED_SOCIAL_PROVIDER(400, "지원하지 않는 소셜 로그인 제공자입니다"),
+    ACCOUNT_NOT_FOUND(404, "계정을 찾을 수 없습니다"),
+    EMAIL_VERIFICATION_REQUIRED(403, "이메일 인증이 필요합니다"),
+
     // jwt 에러
     INVALID_JWT_SIGNATURE(401, "유효하지 않은 JWT 서명입니다"),
     MALFORMED_JWT_TOKEN(401, "잘못된 JWT 토큰입니다"),

--- a/src/main/java/com/kefa/common/exception/ErrorCode.java
+++ b/src/main/java/com/kefa/common/exception/ErrorCode.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ErrorCode {
 
     //인증 관련
+    INVALID_EMAIL_VERIFICATION_TOKEN(400, "유효하지 않은 메일 인증 토큰입니다."),
     INVALID_ROLE(400, "유효하지 않은 권한입니다."),
     DUPLICATE_EMAIL(400, "이미 존재하는 이메일입니다"),
     INVALID_EMAIL_FORMAT(400, "잘못된 이메일 형식입니다"),

--- a/src/main/java/com/kefa/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kefa/common/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.kefa.common.handler;
 
+import com.kefa.common.exception.AuthenticationException;
 import com.kefa.common.exception.ErrorCode;
 import com.kefa.common.exception.JwtAuthenticationException;
 import com.kefa.common.response.ApiResponse;
@@ -13,6 +14,15 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiResponse<?>> handleAuthException(AuthenticationException e) {
+        log.error("AuthenticationException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(ApiResponse.error(ErrorResponse.of(errorCode)));
+    }
+
     @ExceptionHandler(JwtAuthenticationException.class)
     public ResponseEntity<ApiResponse<?>> handleJwtException(JwtAuthenticationException e) {
         log.error("JwtException: {}", e.getMessage());
@@ -21,5 +31,4 @@ public class GlobalExceptionHandler {
             .status(errorCode.getStatus())
             .body(ApiResponse.error(ErrorResponse.of(errorCode)));
     }
-
 }

--- a/src/main/java/com/kefa/domain/entity/Account.java
+++ b/src/main/java/com/kefa/domain/entity/Account.java
@@ -1,8 +1,11 @@
 package com.kefa.domain.entity;
 
+import com.kefa.domain.type.LoginType;
 import com.kefa.domain.type.Role;
 import com.kefa.domain.type.SubscriptionType;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -12,14 +15,18 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Table(name = "accounts")
 @EntityListeners(AuditingEntityListener.class)
 @SQLDelete(sql = "UPDATE accounts SET is_deleted = true, deleted_at = NOW() WHERE id = ?")
-@SQLRestriction("is_deleted = false")  // 수정: is_deleted로 변경
+@SQLRestriction("is_deleted = false")
 public class Account {
 
     @Id
@@ -44,6 +51,15 @@ public class Account {
 
     private boolean isDeleted = false;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "account_login_types",
+        joinColumns = @JoinColumn(name = "account_id")
+    )
+    @Column(name = "login_type")
+    @Enumerated(EnumType.STRING)
+    private Set<LoginType> loginTypes = new HashSet<>();
+
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
@@ -57,4 +73,12 @@ public class Account {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void addLoginType(LoginType loginType) {
+        if (this.loginTypes == null) {
+            this.loginTypes = new HashSet<>();
+        }
+        this.loginTypes.add(loginType);
+    }
+
 }

--- a/src/main/java/com/kefa/domain/entity/Account.java
+++ b/src/main/java/com/kefa/domain/entity/Account.java
@@ -5,6 +5,8 @@ import com.kefa.domain.type.SubscriptionType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -14,8 +16,10 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "account")
+@Table(name = "accounts")
 @EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE accounts SET is_deleted = true, deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("is_deleted = false")  // 수정: is_deleted로 변경
 public class Account {
 
     @Id
@@ -25,14 +29,20 @@ public class Account {
     @Column(unique = true)
     private String email;
 
+    @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false)
     private String password;
 
-    private SubscriptionType subscription_type;
+    @Column(nullable = false)
+    private SubscriptionType subscriptionType;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    private boolean isDeleted = false;
 
     @CreatedDate
     @Column(updatable = false)
@@ -40,4 +50,11 @@ public class Account {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    public void delete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/kefa/domain/entity/Account.java
+++ b/src/main/java/com/kefa/domain/entity/Account.java
@@ -49,7 +49,11 @@ public class Account {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    private boolean isDeleted = false;
+    @Column
+    private boolean verified;
+
+    @Column
+    private boolean isDeleted;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
@@ -58,6 +62,7 @@ public class Account {
     )
     @Column(name = "login_type")
     @Enumerated(EnumType.STRING)
+    @Builder.Default
     private Set<LoginType> loginTypes = new HashSet<>();
 
     @CreatedDate
@@ -79,6 +84,10 @@ public class Account {
             this.loginTypes = new HashSet<>();
         }
         this.loginTypes.add(loginType);
+    }
+
+    public void verify() {
+        this.verified = true;
     }
 
 }

--- a/src/main/java/com/kefa/domain/type/LoginType.java
+++ b/src/main/java/com/kefa/domain/type/LoginType.java
@@ -1,0 +1,16 @@
+package com.kefa.domain.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LoginType {
+
+    LOCAL("일반"),
+    GOOGLE("구글"),
+    KAKAO("카카오");
+
+    private final String description;
+
+}

--- a/src/main/java/com/kefa/domain/vo/AccountVO.java
+++ b/src/main/java/com/kefa/domain/vo/AccountVO.java
@@ -1,0 +1,52 @@
+package com.kefa.domain.vo;
+
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.type.LoginType;
+import com.kefa.domain.type.Role;
+import com.kefa.domain.type.SubscriptionType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Getter
+public class AccountVO {
+
+    private final Long id;
+    private final String email;
+    private final String name;
+    private final SubscriptionType subscriptionType;
+    private final Role role;
+    private final Set<LoginType> loginTypes;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    @Builder
+    private AccountVO(Long id, String email, String name,
+                      SubscriptionType subscriptionType, Role role,
+                      Set<LoginType> loginTypes,
+                      LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.subscriptionType = subscriptionType;
+        this.role = role;
+        this.loginTypes = Set.copyOf(loginTypes);
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static AccountVO from(Account account) {
+        return AccountVO.builder()
+            .id(account.getId())
+            .email(account.getEmail())
+            .name(account.getName())
+            .subscriptionType(account.getSubscriptionType())
+            .role(account.getRole())
+            .loginTypes(account.getLoginTypes())
+            .createdAt(account.getCreatedAt())
+            .updatedAt(account.getUpdatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/kefa/infrastructure/mail/EmailConfig.java
+++ b/src/main/java/com/kefa/infrastructure/mail/EmailConfig.java
@@ -1,0 +1,22 @@
+package com.kefa.infrastructure.mail;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+@ConfigurationProperties(prefix = "spring.mail")
+public class EmailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        return mailSender;
+
+    }
+
+}

--- a/src/main/java/com/kefa/infrastructure/mail/EmailConfig.java
+++ b/src/main/java/com/kefa/infrastructure/mail/EmailConfig.java
@@ -1,20 +1,43 @@
 package com.kefa.infrastructure.mail;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
+import java.util.Properties;
+
+@Setter
+@Getter
 @Configuration
 @ConfigurationProperties(prefix = "spring.mail")
 public class EmailConfig {
+
+    private String host;
+    private int port;
+    private String username;
+    private String password;
 
     @Bean
     public JavaMailSender javaMailSender() {
 
         JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-        mailSender.setHost("smtp.gmail.com");
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.starttls.required", "true");
+        props.put("mail.smtp.ssl.trust", "smtp.gmail.com");
+        props.put("mail.smtp.ssl.protocols", "TLSv1.2");
+
         return mailSender;
 
     }

--- a/src/main/java/com/kefa/infrastructure/mail/EmailSender.java
+++ b/src/main/java/com/kefa/infrastructure/mail/EmailSender.java
@@ -1,0 +1,35 @@
+package com.kefa.infrastructure.mail;
+
+import com.kefa.common.exception.EmailException;
+import com.kefa.common.exception.ErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailSender {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendVerificationEmail(String to, String token) {
+
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(to);
+            helper.setSubject("Kefa 이메일 인증");
+            helper.setText(EmailTemplate.createVerificationEmailContent(token), true);
+
+            javaMailSender.send(message);
+        } catch (MessagingException e) {
+            throw new EmailException(ErrorCode.SERVER_ERROR);
+        }
+
+    }
+
+}

--- a/src/main/java/com/kefa/infrastructure/mail/EmailTemplate.java
+++ b/src/main/java/com/kefa/infrastructure/mail/EmailTemplate.java
@@ -1,0 +1,52 @@
+package com.kefa.infrastructure.mail;
+
+public class EmailTemplate {
+
+    public static String createVerificationEmailContent(String token) {
+        String verificationUrl = String.format("http://localhost:8080/auth/verify?token=%s", token);
+
+        return """
+            <html>
+            <head>
+                <style>
+                    .container {
+                        width: 100%%;
+                        max-width: 600px;
+                        margin: 0 auto;
+                        padding: 20px;
+                        font-family: Arial, sans-serif;
+                    }
+                    .button {
+                        display: inline-block;
+                        padding: 12px 24px;
+                        background-color: #4CAF50;
+                        color: white;
+                        text-decoration: none;
+                        border-radius: 4px;
+                        margin: 20px 0;
+                    }
+                    .message {
+                        color: #666;
+                        line-height: 1.5;
+                    }
+                </style>
+            </head>
+            <body>
+                <div class="container">
+                    <h1>이메일 인증</h1>
+                    <p class="message">
+                        Kefa 서비스에 가입해 주셔서 감사합니다.<br>
+                        아래 버튼을 클릭하여 이메일 인증을 완료해 주세요.
+                    </p>
+                    <a href="%s" class="button">이메일 인증하기</a>
+                    <p class="message">
+                        버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣어 주세요.<br>
+                        %s
+                    </p>
+                </div>
+            </body>
+            </html>
+            """.formatted(verificationUrl, verificationUrl);
+    }
+
+}

--- a/src/main/java/com/kefa/infrastructure/repository/AccountRepository.java
+++ b/src/main/java/com/kefa/infrastructure/repository/AccountRepository.java
@@ -4,7 +4,13 @@ import com.kefa.domain.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    Optional<Account> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 
 }

--- a/src/main/java/com/kefa/infrastructure/repository/EmailVerificationRedisRepository.java
+++ b/src/main/java/com/kefa/infrastructure/repository/EmailVerificationRedisRepository.java
@@ -1,0 +1,36 @@
+package com.kefa.infrastructure.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailVerificationRedisRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final long EMAIL_TOKEN_EXPIRATION = 10 * 60;
+    private static final String EMAIL_VERIFY_PREFIX = "EMAIL_VERIFY_";
+
+    public void saveEmailToken(String token, String email) {
+
+        redisTemplate.opsForValue()
+            .set(
+                EMAIL_VERIFY_PREFIX + token,
+                email,
+                EMAIL_TOKEN_EXPIRATION,
+                TimeUnit.SECONDS
+            );
+
+    }
+
+    public String getEmailByToken(String token) {
+        return redisTemplate.opsForValue().get(EMAIL_VERIFY_PREFIX + token);
+    }
+
+    public void removeEmailToken(String token) {
+        redisTemplate.delete(EMAIL_VERIFY_PREFIX + token);
+    }
+}

--- a/src/main/java/com/kefa/infrastructure/security/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/kefa/infrastructure/security/auth/CustomOAuth2UserService.java
@@ -1,0 +1,59 @@
+package com.kefa.infrastructure.security.auth;
+
+import com.kefa.application.usecase.AuthenticationUseCase;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.domain.vo.AccountVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final AuthenticationUseCase authenticationUseCase;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        String socialProvider = userRequest.getClientRegistration().getRegistrationId();
+        String email = getEmailFromOauth2User(oAuth2User, socialProvider);
+
+        AccountVO accountVO = authenticationUseCase.authenticateSocialUser(email, socialProvider);
+
+        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+        attributes.put("accountId", accountVO.getId());
+
+        return new DefaultOAuth2User(
+            Collections.singleton(new SimpleGrantedAuthority("ROLE_" + accountVO.getRole())),
+            attributes,
+            email
+        );
+
+    }
+
+    private String getEmailFromOauth2User(OAuth2User oauth2User, String registrationId) {
+
+        return switch (registrationId) {
+            case "google" -> oauth2User.getAttribute("email");
+            case "kakao" -> {
+                Map<String, Object> kakaoAccount = oauth2User.getAttribute("kakao_account");
+                yield (String) Objects.requireNonNull(kakaoAccount).get("email");
+            }
+            default -> throw new OAuth2AuthenticationException(ErrorCode.UNSUPPORTED_SOCIAL_PROVIDER.getMessage());
+        };
+
+    }
+
+}

--- a/src/main/java/com/kefa/infrastructure/security/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/kefa/infrastructure/security/auth/CustomOAuth2UserService.java
@@ -34,11 +34,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
         attributes.put("accountId", accountVO.getId());
+        attributes.put("email", email);
+
+        String nameAttributeKey = switch (socialProvider) {
+            case "google" -> "sub";
+            case "kakao" -> "id";
+            default -> throw new OAuth2AuthenticationException(ErrorCode.UNSUPPORTED_SOCIAL_PROVIDER.getMessage());
+        };
 
         return new DefaultOAuth2User(
             Collections.singleton(new SimpleGrantedAuthority("ROLE_" + accountVO.getRole())),
             attributes,
-            email
+            nameAttributeKey
         );
 
     }

--- a/src/main/java/com/kefa/infrastructure/security/auth/CustomUserDetails.java
+++ b/src/main/java/com/kefa/infrastructure/security/auth/CustomUserDetails.java
@@ -20,18 +20,20 @@ public class CustomUserDetails implements UserDetails {
     private final String subscriptionType;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
+    private final boolean deleted;
 
     public CustomUserDetails(Account account) {
         this.id = account.getId();
         this.name = account.getName();
         this.email = account.getEmail();
         this.password = account.getPassword();
-        this.subscriptionType = account.getSubscription_type().toString();
+        this.subscriptionType = account.getSubscriptionType().toString();
         this.authorities = Collections.singleton(
             new SimpleGrantedAuthority("ROLE_" + account.getRole().name())
         );
         this.createdAt = account.getCreatedAt();
         this.updatedAt = account.getUpdatedAt();
+        this.deleted = account.isDeleted();
     }
 
     @Override
@@ -66,6 +68,6 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return !deleted;
     }
 }

--- a/src/main/java/com/kefa/infrastructure/security/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kefa/infrastructure/security/auth/OAuth2SuccessHandler.java
@@ -1,0 +1,74 @@
+package com.kefa.infrastructure.security.auth;
+
+import com.kefa.common.exception.AuthenticationException;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.domain.type.Role;
+import com.kefa.infrastructure.security.jwt.JwtToken;
+import com.kefa.infrastructure.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${oauth2.main-page-uri}")
+    private String mainPageUri;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        try {
+            String roleString = authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElseThrow(() -> new AuthenticationException(ErrorCode.INVALID_ROLE))
+                .replace("ROLE_", "");
+            Role role = Role.valueOf(roleString);
+
+            Long accountId = oAuth2User.getAttribute("accountId");
+
+            JwtToken jwtToken = createJwtToken(accountId, role);
+            addTokenCookie(response, jwtToken);
+
+            getRedirectStrategy().sendRedirect(request, response, mainPageUri);
+
+        } catch (Exception e) {
+            response.sendRedirect(mainPageUri);
+        }
+    }
+
+    private JwtToken createJwtToken(Long accountId, Role role) {
+        String accessToken = jwtTokenProvider.createAccessToken(accountId, role);
+        String refreshToken = jwtTokenProvider.createRefreshToken(accountId, role);
+
+        return JwtToken.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .build();
+    }
+
+    private void addTokenCookie(HttpServletResponse response, JwtToken jwtToken) {
+        Cookie accessTokenCookie = new Cookie("accessToken", jwtToken.getAccessToken());
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge(3600);
+
+        response.addCookie(accessTokenCookie);
+    }
+
+}

--- a/src/main/java/com/kefa/infrastructure/security/cipher/CipherService.java
+++ b/src/main/java/com/kefa/infrastructure/security/cipher/CipherService.java
@@ -1,0 +1,42 @@
+package com.kefa.infrastructure.security.cipher;
+
+import com.kefa.common.exception.CipherException;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.infrastructure.security.config.CipherConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Cipher;
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+public class CipherService {
+
+    private final CipherConfig cipherConfig;
+
+    public String encrypt(String value) {
+
+        try {
+            Cipher cipher = cipherConfig.createCipher(Cipher.ENCRYPT_MODE);
+            byte[] encrypted = cipher.doFinal(value.getBytes());
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            throw new CipherException(ErrorCode.ENCRYPTION_FAILED);
+        }
+
+    }
+
+    public String decrypt(String encryptedValue) {
+
+        try {
+            Cipher cipher = cipherConfig.createCipher(Cipher.DECRYPT_MODE);
+            byte[] decrypted = cipher.doFinal(Base64.getDecoder().decode(encryptedValue));
+            return new String(decrypted);
+        } catch (Exception e) {
+            throw new CipherException(ErrorCode.DECRYPTION_FAILED);
+        }
+
+    }
+
+}

--- a/src/main/java/com/kefa/infrastructure/security/config/CipherConfig.java
+++ b/src/main/java/com/kefa/infrastructure/security/config/CipherConfig.java
@@ -1,0 +1,32 @@
+package com.kefa.infrastructure.security.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+@Configuration
+@RequiredArgsConstructor
+public class CipherConfig {
+
+    private final CipherProperties cipherProperties;
+
+    public Cipher createCipher(int mode) throws Exception {
+
+        SecretKeySpec secretKey = new SecretKeySpec(
+            cipherProperties.getSecretKey().getBytes(),
+            "AES"
+        );
+        IvParameterSpec iv = new IvParameterSpec(
+            cipherProperties.getIv().getBytes()
+        );
+
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(mode, secretKey, iv);
+
+        return cipher;
+
+    }
+}

--- a/src/main/java/com/kefa/infrastructure/security/config/CipherProperties.java
+++ b/src/main/java/com/kefa/infrastructure/security/config/CipherProperties.java
@@ -1,0 +1,19 @@
+package com.kefa.infrastructure.security.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "cipher")
+@Getter
+@Setter
+public class CipherProperties {
+
+    private String secretKey;
+    private String iv;
+
+}
+
+

--- a/src/main/java/com/kefa/infrastructure/security/config/JwtProperties.java
+++ b/src/main/java/com/kefa/infrastructure/security/config/JwtProperties.java
@@ -1,4 +1,4 @@
-package com.kefa.infrastructure.security.jwt;
+package com.kefa.infrastructure.security.config;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
             .exceptionHandling(exception -> exception
                 .authenticationEntryPoint((request, response, authException) -> {
                     response.setContentType("application/json;charset=UTF-8");
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
                     ApiResponse<Void> apiResponse = ApiResponse.error(ErrorResponse.of(ErrorCode.ACCESS_DENIED));
 

--- a/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
@@ -1,9 +1,12 @@
 package com.kefa.infrastructure.security.config;
 
+import com.kefa.infrastructure.security.auth.CustomOAuth2UserService;
+import com.kefa.infrastructure.security.auth.OAuth2SuccessHandler;
 import com.kefa.infrastructure.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.OAuth2LoginDsl;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -19,6 +22,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -33,9 +38,19 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/**", "/public/**").permitAll()
+                .requestMatchers("/auth/**", "/public/**", "/oauth2/**").permitAll()
                 .anyRequest().authenticated()
             )
+            .oauth2Login(oauth2  -> oauth2
+                .authorizationEndpoint(endpoint -> endpoint
+                    .baseUri("/oauth2/authorization"))
+                .redirectionEndpoint(endpoint -> endpoint
+                    .baseUri("/oauth2/*/callback"))
+                .userInfoEndpoint(endpoint -> endpoint
+                    .userService(customOAuth2UserService))
+                .successHandler(oAuth2SuccessHandler)
+            )
+
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .formLogin(AbstractHttpConfigurer::disable)
             .logout(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
@@ -1,12 +1,18 @@
 package com.kefa.infrastructure.security.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kefa.application.usecase.AuthenticationUseCase;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.common.response.ApiResponse;
+import com.kefa.common.response.ErrorResponse;
 import com.kefa.infrastructure.security.auth.CustomOAuth2UserService;
 import com.kefa.infrastructure.security.auth.OAuth2SuccessHandler;
 import com.kefa.infrastructure.security.jwt.JwtAuthenticationFilter;
+
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.OAuth2LoginDsl;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -22,8 +28,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Bean
+    public CustomOAuth2UserService customOAuth2UserService(AuthenticationUseCase authenticationUseCase) {
+        return new CustomOAuth2UserService(authenticationUseCase);
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -31,7 +41,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomOAuth2UserService customOAuth2UserService) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session
@@ -41,7 +51,20 @@ public class SecurityConfig {
                 .requestMatchers("/auth/**", "/public/**", "/oauth2/**").permitAll()
                 .anyRequest().authenticated()
             )
-            .oauth2Login(oauth2  -> oauth2
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+
+                    ApiResponse<Void> apiResponse = ApiResponse.error(ErrorResponse.of(ErrorCode.ACCESS_DENIED));
+
+                    ObjectMapper objectMapper = new ObjectMapper();
+                    String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+
+                    response.getWriter().write(jsonResponse);
+                })
+            )
+            .oauth2Login(oauth2 -> oauth2
                 .authorizationEndpoint(endpoint -> endpoint
                     .baseUri("/oauth2/authorization"))
                 .redirectionEndpoint(endpoint -> endpoint
@@ -50,14 +73,11 @@ public class SecurityConfig {
                     .userService(customOAuth2UserService))
                 .successHandler(oAuth2SuccessHandler)
             )
-
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .formLogin(AbstractHttpConfigurer::disable)
             .logout(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable);
 
         return http.build();
-
     }
-
 }

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtAuthenticationFilter.java
@@ -28,35 +28,46 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+
+        throws ServletException, IOException {
         String token = getTokenFromRequest(request);
 
         if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-
-            Long id = jwtTokenProvider.getId(token);
-            Role role = jwtTokenProvider.getRole(token);
-            Collection<GrantedAuthority> authorities =
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role.name()));
-
-            Authentication authentication = new UsernamePasswordAuthenticationToken(
-                String.valueOf(id),
-                null,
-                authorities
-            );
-
+            Authentication authentication = createAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-
         }
 
         filterChain.doFilter(request, response);
+
+    }
+
+    private Authentication createAuthentication(String token) {
+
+        Long id = jwtTokenProvider.getId(token);
+        Role role = jwtTokenProvider.getRole(token);
+        Collection<GrantedAuthority> authorities = createAuthorities(role);
+
+        return new UsernamePasswordAuthenticationToken(
+            String.valueOf(id),
+            null,
+            authorities
+        );
+
+    }
+
+    private Collection<GrantedAuthority> createAuthorities(Role role) {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role.name()));
     }
 
     private String getTokenFromRequest(HttpServletRequest request) {
+
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(7);
         }
         return null;
+
     }
 
 }

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtProperties.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtProperties.java
@@ -1,18 +1,18 @@
 package com.kefa.infrastructure.security.jwt;
 
 import lombok.Getter;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
 @Getter
-@Component
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 
-    @Value("${jwt.key}")
     private String key;
-    @Value("${jwt.access-expiration-time}")
     private long accessExpirationTime;
-    @Value("${jwt.refresh-expiration-time}")
     private long refreshExpirationTime;
 
 }

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtToken.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtToken.java
@@ -1,10 +1,14 @@
 package com.kefa.infrastructure.security.jwt;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class JwtToken {
 
     private String accessToken;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,11 @@ spring:
     properties:
       hibernate:
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT}
+
 jwt:
   key: ${JWT_KEY}
   access-expiration-time: ${JWT_ACCESS_EXPIRATION_TIME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,45 @@ spring:
   application:
     name: kefa
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/oauth2/google/callback"
+            scope:
+              - email
+              - profile
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/oauth2/kakao/callback"
+            scope:
+              - profile_nickname
+              - account_email
+
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     username: ${DB_USER}
@@ -19,3 +58,10 @@ jwt:
   key: ${JWT_KEY}
   access-expiration-time: ${JWT_ACCESS_EXPIRATION_TIME}
   refresh-expiration-time: ${JWT_REFRESH_EXPIRATION_TIME}
+
+oauth2:
+  main-page-uri: ${OAUTH2_MAIN_PAGE_URI}
+
+cipher:
+  secret-key: ${CIPHER_SECRET_KEY}
+  iv: ${CIPHER_IV}

--- a/src/test/java/com/kefa/application/service/AccountServiceTest.java
+++ b/src/test/java/com/kefa/application/service/AccountServiceTest.java
@@ -1,0 +1,84 @@
+package com.kefa.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kefa.api.dto.request.AccountSignupRequestDto;
+import com.kefa.api.dto.response.AccountSignupResponseDto;
+import com.kefa.application.usecase.AuthenticationUseCase;
+import com.kefa.application.usecase.EmailVerificationUseCase;
+import com.kefa.common.exception.AuthenticationException;
+import com.kefa.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AccountServiceTest {
+
+    @Mock
+    private AuthenticationUseCase authenticationUseCase;
+
+    @Mock
+    private EmailVerificationUseCase emailVerificationUseCase;
+
+    @InjectMocks
+    private AccountService accountService;
+
+    @Test
+    @DisplayName("일반 회원가입 성공시 이메일 인증메일을 발송한다")
+    void signup_success() {
+        // given
+        AccountSignupRequestDto request = AccountSignupRequestDto.builder()
+            .email("test@email.com")
+            .password("password")
+            .name("name")
+            .build();
+
+        AccountSignupResponseDto expectedResponse = AccountSignupResponseDto.builder()
+            .id(1L)
+            .email("test@email.com")
+            .name("name")
+            .build();
+
+        when(authenticationUseCase.signup(request)).thenReturn(expectedResponse);
+        doNothing().when(emailVerificationUseCase).sendVerificationEmail(request.getEmail());
+
+        // when
+        AccountSignupResponseDto response = accountService.signup(request);
+
+        // then
+        assertThat(response).isEqualTo(expectedResponse);
+        verify(authenticationUseCase).signup(request);
+        verify(emailVerificationUseCase).sendVerificationEmail(request.getEmail());
+    }
+
+    @Test
+    @DisplayName("회원가입 실패시 이메일 발송하지 않는다")
+    void signup_fail() {
+        // given
+        AccountSignupRequestDto request = AccountSignupRequestDto.builder()
+            .email("test@email.com")
+            .password("password")
+            .name("name")
+            .build();
+
+        when(authenticationUseCase.signup(request))
+            .thenThrow(new AuthenticationException(ErrorCode.DUPLICATE_EMAIL));
+
+        // when & then
+        assertThatThrownBy(() -> accountService.signup(request))
+            .isInstanceOf(AuthenticationException.class);
+
+        verify(authenticationUseCase).signup(request);
+        verify(emailVerificationUseCase, never()).sendVerificationEmail(any());
+    }
+}

--- a/src/test/java/com/kefa/application/usecase/AuthenticationUseCaseTest.java
+++ b/src/test/java/com/kefa/application/usecase/AuthenticationUseCaseTest.java
@@ -1,0 +1,164 @@
+package com.kefa.application.usecase;
+
+import com.kefa.api.dto.request.AccountSignupRequestDto;
+import com.kefa.api.dto.response.AccountSignupResponseDto;
+import com.kefa.common.exception.AuthenticationException;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.type.LoginType;
+import com.kefa.domain.type.Role;
+import com.kefa.domain.type.SubscriptionType;
+import com.kefa.domain.vo.AccountVO;
+import com.kefa.infrastructure.repository.AccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationUseCaseTest {
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthenticationUseCase authenticationUseCase;
+
+    private AccountSignupRequestDto requestDto;
+
+    @BeforeEach
+    void setUp() {
+        requestDto = AccountSignupRequestDto.builder()
+            .email("test@example.com")
+            .password("password123")
+            .build();
+    }
+
+    @Test
+    @DisplayName("일반 회원가입 성공")
+    void signupSuccess() {
+        // given
+        Account account = Account.builder()
+            .id(1L)
+            .email("test@example.com")
+            .name("name")
+            .password("encodedPassword")
+            .subscriptionType(SubscriptionType.FREE)
+            .role(Role.ACCOUNT)
+            .verified(false)
+            .loginTypes(Set.of(LoginType.LOCAL))
+            .build();
+
+        when(accountRepository.existsByEmail(requestDto.getEmail())).thenReturn(false);
+        when(passwordEncoder.encode(requestDto.getPassword())).thenReturn("encodedPassword");
+        when(accountRepository.save(any(Account.class))).thenReturn(account);
+
+        // when
+        AccountSignupResponseDto responseDto = authenticationUseCase.signup(requestDto);
+
+        // then
+        assertThat(responseDto.getEmail()).isEqualTo(requestDto.getEmail());
+        verify(accountRepository).save(argThat(savedAccount ->
+            savedAccount.getEmail().equals(requestDto.getEmail()) &&
+                savedAccount.getLoginTypes().contains(LoginType.LOCAL) &&
+                savedAccount.getRole() == Role.ACCOUNT &&
+                !savedAccount.isVerified() &&
+                savedAccount.getSubscriptionType() == SubscriptionType.FREE
+        ));
+    }
+
+    @Test
+    @DisplayName("중복 이메일로 인한 회원가입 실패")
+    void signupDuplicateEmailFailure() {
+        // given
+        when(accountRepository.existsByEmail(requestDto.getEmail())).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> authenticationUseCase.signup(requestDto))
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessageContaining(ErrorCode.DUPLICATE_EMAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("소셜 로그인 성공, 신규 사용자 계정 생성")
+    void Oauth2JoinAndLoginSuccess() {
+        // given
+        Account newAccount = Account.builder()
+            .id(1L)
+            .email("test@example.com")
+            .name("name")
+            .subscriptionType(SubscriptionType.FREE)
+            .role(Role.ACCOUNT)
+            .verified(true)
+            .loginTypes(Set.of(LoginType.GOOGLE))
+            .build();
+
+        when(accountRepository.findByEmail("test@example.com")).thenReturn(Optional.empty());
+        when(accountRepository.save(any(Account.class))).thenReturn(newAccount);
+
+        // when
+        AccountVO accountVO = authenticationUseCase.authenticateSocialUser("test@example.com", "google");
+
+        // then
+        assertThat(accountVO.getEmail()).isEqualTo("test@example.com");
+        verify(accountRepository).save(argThat(savedAccount ->
+            savedAccount.getEmail().equals("test@example.com") &&
+                savedAccount.getLoginTypes().contains(LoginType.GOOGLE) &&
+                savedAccount.getRole() == Role.ACCOUNT &&
+                savedAccount.isVerified() &&
+                savedAccount.getSubscriptionType() == SubscriptionType.FREE
+        ));
+    }
+
+    @Test
+    @DisplayName("소셜 로그인 성공, 기존 사용자는 저장하지 않음")
+    void Oauth2LoginSuccess() {
+        // given
+        Account existingAccount = Account.builder()
+            .id(1L)
+            .email("test@example.com")
+            .name("name")
+            .subscriptionType(SubscriptionType.FREE)
+            .role(Role.ACCOUNT)
+            .verified(true)
+            .loginTypes(Set.of(LoginType.GOOGLE))
+            .build();
+
+        when(accountRepository.findByEmail("test@example.com"))
+            .thenReturn(Optional.of(existingAccount));
+
+        // when
+        AccountVO accountVO = authenticationUseCase.authenticateSocialUser("test@example.com", "google");
+
+        // then
+        assertThat(accountVO.getEmail()).isEqualTo("test@example.com");
+        assertThat(existingAccount.getLoginTypes()).contains(LoginType.GOOGLE);
+        assertThat(existingAccount.isVerified()).isEqualTo(true);
+        verify(accountRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 소셜 로그인 시도 실패")
+    void unsupportedOAuth2ProviderLoginFailed() {
+        // when & then
+        assertThatThrownBy(() ->
+            authenticationUseCase.authenticateSocialUser("test@example.com", "unknown"))
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessageContaining(ErrorCode.UNSUPPORTED_SOCIAL_PROVIDER.getMessage());
+    }
+}

--- a/src/test/java/com/kefa/application/usecase/EmailVerificationUseCaseTest.java
+++ b/src/test/java/com/kefa/application/usecase/EmailVerificationUseCaseTest.java
@@ -1,0 +1,63 @@
+package com.kefa.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.kefa.infrastructure.mail.EmailSender;
+import com.kefa.infrastructure.repository.EmailVerificationRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailVerificationUseCaseTest {
+
+    @Mock
+    private EmailVerificationRedisRepository emailVerificationRedisRepository;
+
+    @Mock
+    private EmailSender emailSender;
+
+    @InjectMocks
+    private EmailVerificationUseCase emailVerificationUseCase;
+
+    @Test
+    @DisplayName("이메일 인증 메일 발송 성공")
+    void sendVerificationEmail_success() {
+        // given
+        String email = "test@email.com";
+
+        doNothing().when(emailVerificationRedisRepository).saveEmailToken(any(), eq(email));
+        doNothing().when(emailSender).sendVerificationEmail(eq(email), any());
+
+        // when
+        emailVerificationUseCase.sendVerificationEmail(email);
+
+        // then
+        verify(emailVerificationRedisRepository).saveEmailToken(any(), eq(email));
+        verify(emailSender).sendVerificationEmail(eq(email), any());
+    }
+
+    @Test
+    @DisplayName("Redis 저장 실패시 이메일 발송하지 않음")
+    void sendVerificationEmail_failOnRedis() {
+        // given
+        String email = "test@email.com";
+        doThrow(new RuntimeException()).when(emailVerificationRedisRepository).saveEmailToken(any(), eq(email));
+
+        // when & then
+        assertThatThrownBy(() -> emailVerificationUseCase.sendVerificationEmail(email))
+            .isInstanceOf(RuntimeException.class);
+
+        verify(emailVerificationRedisRepository).saveEmailToken(any(), eq(email));
+        verify(emailSender, never()).sendVerificationEmail(any(), any());
+    }
+}

--- a/src/test/java/com/kefa/infrastructure/security/auth/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/auth/CustomUserDetailsServiceTest.java
@@ -1,0 +1,100 @@
+package com.kefa.infrastructure.security.auth;
+
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.type.LoginType;
+import com.kefa.domain.type.Role;
+import com.kefa.domain.type.SubscriptionType;
+import com.kefa.infrastructure.repository.AccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomUserDetailsServiceTest {
+
+    @InjectMocks
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    private Account account;
+
+    @BeforeEach
+    void setUp() {
+        account = Account.builder()
+            .id(1L)
+            .email("test@example.com")
+            .password("password")
+            .loginTypes(Set.of(LoginType.LOCAL))
+            .subscriptionType(SubscriptionType.FREE)
+            .role(Role.ACCOUNT)
+            .build();
+    }
+
+    @Test
+    @DisplayName("사용자 ID로 식별자 확인")
+    void checkUsername() {
+        // given
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+
+        // when
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername("1");
+
+        // then
+        assertThat(userDetails.getUsername()).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("사용자 비밀번호 확인")
+    void checkPassword() {
+        // given
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+
+        // when
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername("1");
+
+        // then
+        assertThat(userDetails.getPassword()).isEqualTo("password");
+    }
+
+    @Test
+    @DisplayName("사용자 권한 확인")
+    void checkAuthorities() {
+        // given
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+
+        // when
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername("1");
+
+        // then
+        assertThat(userDetails.getAuthorities())
+            .hasSize(1)
+            .extracting("authority")
+            .contains("ROLE_" + Role.ACCOUNT.name());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 예외 테스트")
+    void loadUserByUsername_NotFound() {
+        // given
+        when(accountRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername("1"))
+            .isInstanceOf(UsernameNotFoundException.class);
+    }
+}

--- a/src/test/java/com/kefa/infrastructure/security/cipher/CipherServiceTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/cipher/CipherServiceTest.java
@@ -1,0 +1,52 @@
+package com.kefa.infrastructure.security.cipher;
+
+import com.kefa.infrastructure.security.config.CipherConfig;
+import com.kefa.infrastructure.security.config.CipherProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CipherServiceTest {
+
+    private CipherService cipherService;
+
+    @BeforeEach
+    void setUp() {
+        CipherProperties cipherProperties = new CipherProperties();
+        cipherProperties.setSecretKey("1234567890123456");
+        cipherProperties.setIv("abcdefghijklmnop");
+
+        CipherConfig cipherConfig = new CipherConfig(cipherProperties);
+        cipherService = new CipherService(cipherConfig);
+    }
+
+    @Test
+    @DisplayName("문자열 암호화 성공 테스트")
+    void encryptSuccess() {
+        // given
+        String originalText = "text";
+
+        // when
+        String encryptedText = cipherService.encrypt(originalText);
+
+        // then
+        assertThat(encryptedText).isNotEqualTo(originalText);
+        assertThat(encryptedText).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("문자열 복호화 성공 테스트")
+    void decryptSuccess() {
+        // given
+        String originalText = "text";
+        String encryptedText = cipherService.encrypt(originalText);
+
+        // when
+        String decryptedText = cipherService.decrypt(encryptedText);
+
+        // then
+        assertThat(decryptedText).isEqualTo(originalText);
+    }
+}

--- a/src/test/java/com/kefa/infrastructure/security/config/PasswordEncoderTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/config/PasswordEncoderTest.java
@@ -1,0 +1,47 @@
+package com.kefa.infrastructure.security.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PasswordEncoderTest {
+
+    private PasswordEncoder passwordEncoder;
+    private String password;
+    private String encodedPassword;
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = new BCryptPasswordEncoder();
+        password = "passwordTest";
+        encodedPassword = passwordEncoder.encode(password);
+    }
+
+    @Test
+    @DisplayName("기존 비밀번호와 암호화된 비밀번호 다름")
+    void passwordDifferentTest() {
+        assertThat(encodedPassword).isNotEqualTo(password);
+    }
+
+    @Test
+    @DisplayName("암호화된 비밀번호 BCrypt 형식 확인")
+    void passwordFormatTest() {
+        assertThat(encodedPassword).startsWith("$2a$");
+    }
+
+    @Test
+    @DisplayName("비밀번호와 암호화된 비밀번호 검증 성공")
+    void passwordMatchSuccessTest() {
+        assertThat(passwordEncoder.matches(password, encodedPassword)).isTrue();
+    }
+
+    @Test
+    @DisplayName("비밀번호와 암호화된 비밀번호 검증 실패")
+    void passwordMatchFailTest() {
+        assertThat(passwordEncoder.matches("wrongPassword", encodedPassword)).isFalse();
+    }
+}

--- a/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
@@ -61,7 +61,7 @@ public class SecurityConfigTest {
 
         for (String url : protectedUrls) {
             mockMvc.perform(get(url))
-                .andExpect(status().isForbidden())
+                .andExpect(status().isUnauthorized())
                 .andDo(print());
         }
 

--- a/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
@@ -4,9 +4,9 @@ import com.kefa.infrastructure.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(SecurityConfig.class)
-@MockBean(JpaMetamodelMappingContext.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 public class SecurityConfigTest {
 
     @MockBean
@@ -35,7 +35,7 @@ public class SecurityConfigTest {
     @Test
     @DisplayName("공개 엔드포인드 접근 가능 성공")
     void publicEndpointsSuccessTest() throws Exception {
-        // 공개 URL 목록
+
         List<String> publicUrls = Arrays.asList(
             "/auth/login",
             "/auth/join",
@@ -44,8 +44,9 @@ public class SecurityConfigTest {
 
         for (String url : publicUrls) {
             mockMvc.perform(get(url))
-                .andExpect(status().isNotFound()); // 추후 리소스 만든 후 isOk();로 변경해야 함
+                .andExpect(status().isNotFound());
         }
+
     }
 
     @Test
@@ -63,6 +64,7 @@ public class SecurityConfigTest {
                 .andExpect(status().isForbidden())
                 .andDo(print());
         }
+
     }
 
     @Test

--- a/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
@@ -7,14 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -23,17 +20,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class SecurityConfigTest {
 
-    @MockBean
-    private JwtTokenProvider jwtTokenProvider;
     @Autowired
     private MockMvc mockMvc;
 
-    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-    private final String password = "passwordTest";
-    private final String encodedPassword = passwordEncoder.encode(password);
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
 
     @Test
-    @DisplayName("공개 엔드포인드 접근 가능 성공")
+    @DisplayName("공개 엔드포인트 접근 가능 성공")
     void publicEndpointsSuccessTest() throws Exception {
 
         List<String> publicUrls = Arrays.asList(
@@ -46,7 +40,6 @@ public class SecurityConfigTest {
             mockMvc.perform(get(url))
                 .andExpect(status().isNotFound());
         }
-
     }
 
     @Test
@@ -64,32 +57,5 @@ public class SecurityConfigTest {
                 .andExpect(status().isUnauthorized())
                 .andDo(print());
         }
-
     }
-
-    @Test
-    @DisplayName("기존 비밀번호화 암호화된 비밀번호 다름")
-    void passwordDifferentTest() {
-        assertThat(encodedPassword).isNotEqualTo(password);
-    }
-
-    @Test
-    @DisplayName("암호화된 비밀번호 BCrypt 형식 확인")
-    void passwordFormatTest() {
-        assertThat(encodedPassword).startsWith("$2a$");
-    }
-
-    @Test
-    @DisplayName("비밀번호와 암호화된 비밀번호 검증 성공")
-    void passwordMatchSuccessTest() {
-        assertThat(passwordEncoder.matches(password, encodedPassword)).isTrue();
-    }
-
-    @Test
-    @DisplayName("비밀번호와 암호화된 비밀번호 검증 실패")
-    void passwordMatchFailTest() {
-        assertThat(passwordEncoder.matches("wrongPassword", encodedPassword)).isFalse();
-    }
-
-
 }

--- a/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
@@ -1,12 +1,15 @@
 package com.kefa.infrastructure.security.config;
 
+import com.kefa.application.usecase.AuthenticationUseCase;
+import com.kefa.infrastructure.security.auth.OAuth2SuccessHandler;
 import com.kefa.infrastructure.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
@@ -16,8 +19,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@WebMvcTest(SecurityConfig.class)
 @AutoConfigureMockMvc
+@MockBean(JpaMetamodelMappingContext.class)
 public class SecurityConfigTest {
 
     @Autowired
@@ -26,10 +30,15 @@ public class SecurityConfigTest {
     @MockBean
     private JwtTokenProvider jwtTokenProvider;
 
+    @MockBean
+    private OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @MockBean
+    private AuthenticationUseCase authenticationUseCase;
+
     @Test
     @DisplayName("공개 엔드포인트 접근 가능 성공")
     void publicEndpointsSuccessTest() throws Exception {
-
         List<String> publicUrls = Arrays.asList(
             "/auth/login",
             "/auth/join",
@@ -45,7 +54,6 @@ public class SecurityConfigTest {
     @Test
     @DisplayName("보호된 엔드포인트 접근 실패")
     void protectedEndpointsFailTest() throws Exception {
-
         List<String> protectedUrls = Arrays.asList(
             "/member/profile",
             "/admin/profile",

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,7 +16,41 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
 
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+        registration:
+          google:
+            client-id: asdsadsad
+            client-secret: asdasdsadsad
+            redirect-uri: "localhost:8080/oauth2/google/callback"
+            scope:
+              - email
+              - profile
+          kakao:
+            client-id: asdasdasd
+            client-secret: asdasdasd
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "localhost:8080/oauth2/kakao/callback"
+            scope:
+              - profile_nickname
+              - account_email
+
 jwt:
-  key: testSecretKeytestSecretKeytestSecretKeytestSecretKeytestSecretKeytestSecretKey
+  key: VGhpc0lzVGVzdFNlY3JldEtleUZvckp3dFRva2VuR2VuZXJhdGlvbkFuZFZhbGlkYXRpb25Qcm9jZXNzMjAyNA==
   access-expiration-time: 3600000
   refresh-expiration-time: 1209600000
+
+oauth2:
+  main-page-uri: http://localhost:8080
+
+cipher:
+  secret-key: "TestSecretKey123456TestSecretKey12"
+  iv: "TestIvKey1234567"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,6 +8,10 @@ spring:
     password:
     driver-class-name: org.h2.Driver
 
+  h2:
+    console:
+      enabled: true
+
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -15,6 +19,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
   security:
     oauth2:


### PR DESCRIPTION
## 📎 Issue
  <!-- 관련 이슈 번호를 적어주세요 -->
#23 

## 💫 작업 내용
  <!-- 작업한 내용을 설명해주세요 -->
- 구현 내용 요약
1. 일반 회원가입 시 이메일 중복 검사 및 이메일 소유를 위해 검증 메일 발송
2. Oauth2 로그인 구현 google, kakao 만 추가 kakao는 추후 비즈앱으로 변경해야 email 받아올 수 있음
3. 회원가입시 비밀번호 암호화
4. 컨트롤러를 제외한 나머지 단위 테스트 추가

- 변경사항 설명
- JWT에 들어가는 정보 암호화
- 환경변수 추가로 인한 젠킨스 파일 수정
- 회원 엔티티 필드 추가

## ✅ 체크리스트
- [x] 변경 사항에 대한 테스트를 진행했습니다.
- [x] 불필요한 코드가 없습니다.
