### PR TITLE
feat: 단일 회원 조회 기능 추가

### DIFF
--- a/src/main/java/com/kefa/api/controller/AccountController.java
+++ b/src/main/java/com/kefa/api/controller/AccountController.java
@@ -2,15 +2,18 @@ package com.kefa.api.controller;
 
 import com.kefa.api.dto.request.AccountLoginRequestDto;
 import com.kefa.api.dto.request.AccountSignupRequestDto;
+import com.kefa.api.dto.response.AccountResponseDto;
 import com.kefa.api.dto.response.AccountSignupResponseDto;
 import com.kefa.api.dto.response.TokenResponse;
 import com.kefa.application.service.AccountService;
 import com.kefa.common.response.ApiResponse;
+import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -20,6 +23,14 @@ import java.util.UUID;
 public class AccountController {
 
     private final AccountService accountService;
+
+    @GetMapping("/account/{id}")
+    public ApiResponse<AccountResponseDto> getAccount(@PathVariable Long id, Authentication authentication) {
+
+        AuthenticationInfo authenticationInfo = AuthenticationInfo.from(authentication);
+
+        return ApiResponse.success(accountService.getAccount(id, authenticationInfo));
+    }
 
     @PostMapping("/auth/signup")
     public ApiResponse<AccountSignupResponseDto> addAccount(@RequestBody @Valid AccountSignupRequestDto accountSignupRequestDto) {

--- a/src/main/java/com/kefa/api/dto/response/AccountResponseDto.java
+++ b/src/main/java/com/kefa/api/dto/response/AccountResponseDto.java
@@ -1,0 +1,43 @@
+package com.kefa.api.dto.response;
+
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.type.LoginType;
+import com.kefa.domain.type.Role;
+import com.kefa.domain.type.SubscriptionType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AccountResponseDto {
+
+    private Long id;
+    private String email;
+    private String name;
+    private SubscriptionType subscriptionType;
+    private Role role;
+    private boolean emailVerified;
+    private Set<LoginType> loginTypes;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static AccountResponseDto from(Account account) {
+        return AccountResponseDto.builder()
+            .id(account.getId())
+            .email(account.getEmail())
+            .name(account.getName())
+            .subscriptionType(account.getSubscriptionType())
+            .role(account.getRole())
+            .emailVerified(account.isEmailVerified())
+            .loginTypes(account.getLoginTypes())
+            .createdAt(account.getCreatedAt())
+            .updatedAt(account.getUpdatedAt())
+            .build();
+    }
+
+}

--- a/src/main/java/com/kefa/application/service/AccountService.java
+++ b/src/main/java/com/kefa/application/service/AccountService.java
@@ -3,9 +3,14 @@ package com.kefa.application.service;
 import com.kefa.api.dto.request.AccountLoginRequestDto;
 import com.kefa.api.dto.request.AccountSignupRequestDto;
 import com.kefa.api.dto.response.AccountSignupResponseDto;
+import com.kefa.api.dto.response.AccountResponseDto;
 import com.kefa.api.dto.response.TokenResponse;
+import com.kefa.application.usecase.AccountUseCase;
 import com.kefa.application.usecase.AuthenticationUseCase;
 import com.kefa.application.usecase.EmailVerificationUseCase;
+import com.kefa.common.exception.AuthenticationException;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AccountService {
 
+    private final AccountUseCase accountUseCase;
     private final AuthenticationUseCase authenticationUseCase;
     private final EmailVerificationUseCase emailVerificationUseCase;
+
+    public AccountResponseDto getAccount(Long targetId, AuthenticationInfo authenticationInfo) {
+        return accountUseCase.getAccount(targetId, authenticationInfo);
+    }
 
     @Transactional
     public AccountSignupResponseDto signup(AccountSignupRequestDto request) {

--- a/src/main/java/com/kefa/application/usecase/AccountUseCase.java
+++ b/src/main/java/com/kefa/application/usecase/AccountUseCase.java
@@ -1,0 +1,28 @@
+package com.kefa.application.usecase;
+
+import com.kefa.api.dto.response.AccountResponseDto;
+import com.kefa.common.exception.AuthenticationException;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.infrastructure.repository.AccountRepository;
+import com.kefa.infrastructure.security.auth.AuthenticationInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountUseCase {
+
+    private final AccountRepository accountRepository;
+
+    public AccountResponseDto getAccount(Long targetId, AuthenticationInfo authenticationInfo) {
+        validateAccountAccess(targetId, authenticationInfo.getId());
+        return AccountResponseDto.from(accountRepository.findById(targetId).orElseThrow(() -> new AuthenticationException(ErrorCode.ACCOUNT_NOT_FOUND)));
+    }
+
+    private void validateAccountAccess(Long targetId, Long loginUserId) {
+        if(!targetId.equals(loginUserId)){
+            throw new AuthenticationException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+
+}

--- a/src/main/java/com/kefa/application/usecase/AuthenticationUseCase.java
+++ b/src/main/java/com/kefa/application/usecase/AuthenticationUseCase.java
@@ -41,8 +41,6 @@ public class AuthenticationUseCase {
 
         RefreshToken refreshTokenEntity = createRefreshTokenEntity(account, tokenResponse, accountLoginRequestDto.getDeviceId());
 
-        account.addRefreshToken(refreshTokenEntity);
-
         refreshTokenRepository.save(refreshTokenEntity);
 
         return tokenResponse;
@@ -57,7 +55,7 @@ public class AuthenticationUseCase {
 
         return RefreshToken.builder()
             .token(tokenResponse.getRefreshToken())
-            .account(account)
+            .accountId(account.getId())
             .deviceId(deviceId)
             .expiresAt(jwtProvider.getTokenExpiration(tokenResponse.getRefreshToken()))
             .build();

--- a/src/main/java/com/kefa/common/exception/ErrorCode.java
+++ b/src/main/java/com/kefa/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     EMAIL_VERIFICATION_REQUIRED(403, "이메일 인증이 필요합니다"),
     UNAUTHORIZED(401, "인증이 필요한 서비스입니다"),
     ACCESS_DENIED(403, "접근 권한이 없습니다"),
+    AUTHORITY_NOT_FOUND(401, "권한 정보를 찾을 수 없습니다"),
 
     // jwt 에러
     INVALID_JWT_SIGNATURE(401, "유효하지 않은 JWT 서명입니다"),
@@ -32,7 +33,6 @@ public enum ErrorCode {
     SERVER_ERROR(500, "서버 내부 오류 발생"),
     ENCRYPTION_FAILED(500, "데이터 암호화 처리 중 오류가 발생했습니다"),
     DECRYPTION_FAILED(500, "데이터 복호화 처리 중 오류가 발생했습니다");
-
 
     private final int status;
     private final String message;

--- a/src/main/java/com/kefa/domain/entity/Account.java
+++ b/src/main/java/com/kefa/domain/entity/Account.java
@@ -50,17 +50,13 @@ public class Account {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Builder.Default
-    @OneToMany(mappedBy = "account")
-    private Set<RefreshToken> refreshTokens = new HashSet<>();
-
     @Column
     private boolean emailVerified;
 
     @Column
     private boolean isDeleted;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(
         name = "account_login_types",
         joinColumns = @JoinColumn(name = "account_id")
@@ -90,14 +86,6 @@ public class Account {
 
     public void verify() {
         this.emailVerified = true;
-    }
-
-    public void addRefreshToken(RefreshToken refreshToken) {
-        this.refreshTokens.add(refreshToken);
-    }
-
-    public void removeRefreshToken(RefreshToken refreshToken) {
-        this.refreshTokens.remove(refreshToken);
     }
 
 }

--- a/src/main/java/com/kefa/domain/entity/RefreshToken.java
+++ b/src/main/java/com/kefa/domain/entity/RefreshToken.java
@@ -19,9 +19,7 @@ public class RefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "account_id")
-    private Account account;
+    private Long accountId;
 
     @Column(nullable = false)
     private String token;

--- a/src/main/java/com/kefa/infrastructure/security/auth/AuthenticationInfo.java
+++ b/src/main/java/com/kefa/infrastructure/security/auth/AuthenticationInfo.java
@@ -1,0 +1,25 @@
+package com.kefa.infrastructure.security.auth;
+
+import com.kefa.domain.type.Role;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.Authentication;
+
+@Getter
+@Builder
+public class AuthenticationInfo {
+
+    private Long id;
+    private Role role;
+
+    public static AuthenticationInfo from(Authentication authentication) {
+        return AuthenticationInfo.builder()
+            .id(Long.parseLong(authentication.getName()))
+            .role(Role.valueOf(
+                authentication.getAuthorities().iterator().next()
+                    .getAuthority().replace("ROLE_", "")
+            ))
+            .build();
+    }
+
+}

--- a/src/test/java/com/kefa/application/usecase/AccountUseCaseTest.java
+++ b/src/test/java/com/kefa/application/usecase/AccountUseCaseTest.java
@@ -1,0 +1,103 @@
+package com.kefa.application.usecase;
+
+
+import com.kefa.api.dto.response.AccountResponseDto;
+import com.kefa.common.exception.AuthenticationException;
+import com.kefa.common.exception.ErrorCode;
+import com.kefa.domain.entity.Account;
+import com.kefa.infrastructure.repository.AccountRepository;
+import com.kefa.infrastructure.security.auth.AuthenticationInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class AccountUseCaseTest {
+
+    @InjectMocks
+    private AccountUseCase accountUseCase;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    private Account account;
+
+    @BeforeEach
+    void setUp() {
+        account = Account.builder()
+            .id(1L)
+            .email("test@test.com")
+            .name("test")
+            .build();
+    }
+
+    @DisplayName("회원 조회 성공 - 본인")
+    @Test
+    void getAccountSuccess() {
+
+        //given
+        Long targetId = 1L;
+        AuthenticationInfo authenticationInfo = AuthenticationInfo.builder()
+            .id(targetId)
+            .build();
+        given(accountRepository.findById(targetId)).willReturn(Optional.of(account));
+
+        //when
+        AccountResponseDto result = accountUseCase.getAccount(targetId, authenticationInfo);
+
+        //then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(targetId);
+        assertThat(result.getEmail()).isEqualTo(account.getEmail());
+        assertThat(result.getName()).isEqualTo(account.getName());
+
+    }
+
+    @DisplayName("")
+    @Test
+    void getAccountFai_AccessDenied() {
+
+        //given
+        Long targetId = 2L;
+        AuthenticationInfo authenticationInfo = AuthenticationInfo.builder()
+            .id(account.getId())
+            .build();
+
+        //when & then
+        assertThatThrownBy(() -> accountUseCase.getAccount(targetId, authenticationInfo))
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessage(ErrorCode.ACCESS_DENIED.getMessage());
+
+    }
+
+    @DisplayName("")
+    @Test
+    void getAccountFailAccountNotFound() {
+
+        //given
+        Long targetId = 1L;
+        AuthenticationInfo authenticationInfo = AuthenticationInfo.builder()
+            .id(targetId)
+            .build();
+        given(accountRepository.findById(any())).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> accountUseCase.getAccount(targetId, authenticationInfo))
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessage(ErrorCode.ACCOUNT_NOT_FOUND.getMessage());
+
+    }
+
+
+}

--- a/src/test/java/com/kefa/application/usecase/AuthenticationUseCaseTest.java
+++ b/src/test/java/com/kefa/application/usecase/AuthenticationUseCaseTest.java
@@ -51,7 +51,7 @@ class AuthenticationUseCaseTest {
     private AuthenticationUseCase authenticationUseCase;
 
     private AccountSignupRequestDto signupRequestDto;
-    AccountLoginRequestDto loginRequest;
+    private AccountLoginRequestDto loginRequest;
 
 
     @BeforeEach
@@ -101,7 +101,7 @@ class AuthenticationUseCaseTest {
         verify(refreshTokenRepository).save(argThat(savedToken ->
             savedToken.getToken().equals(refreshToken) &&
                 savedToken.getDeviceId().equals(loginRequest.getDeviceId()) &&
-                savedToken.getAccount().equals(account) &&
+                savedToken.getAccountId().equals(account.getId()) &&
                 savedToken.getExpiresAt().equals(expirationTime)
         ));
     }


### PR DESCRIPTION
## 📎 Issue
#23 

## 💫 작업 내용
- 구현 내용 요약
  1. 로그인 한 회원과 조회하는 회원의 식별자가 같을 경우 조회 성공
  2. RefreshToken과 Account 엔티티 간 연관관계 제거

- 변경사항 상세 설명
  1. RefreshToken과 Account 엔티티 연관관계 제거
     - 단순 인증 처리만 필요하여 불필요한 연관관계 제거
  2. RefreshToken 엔티티 구조 변경
     - Account 객체 참조 대신 accountId만 저장

## 🔍 테스트
- [x] 단일 회원 조회 성공 테스트
- [x] 단일 회원 조회 식별자 불일치로 인한 실패 테스트
- [x] 단일 회원 조회 회원이 존재하지 않음으로 인한 실패 테스트

## ✅ 체크리스트
- [x] 변경 사항에 대한 테스트를 진행했습니다.
- [x] 불필요한 코드가 없습니다.