### PR TITLE
feat: 회원 정보 수정 기능 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,8 @@ services:
     restart: always
     ports:
       - "${SERVER_PORT}:${SERVER_PORT}"
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://db:${DB_PORT}/${DB_NAME}
-      SPRING_DATASOURCE_USERNAME: ${DB_USER}
-      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
-      SPRING_REDIS_HOST: redis
+    env_file:
+      - .env
     depends_on:
       - db
       - redis
@@ -58,17 +55,10 @@ services:
     volumes:
       - jenkins_home:/var/jenkins_home
       - /var/run/docker.sock:/var/run/docker.sock
+    env_file:
+      - .env
     environment:
-      - TZ=${TZ}
       - JAVA_OPTS="-Dhudson.security.csrf.GlobalCrumbIssuerConfiguration.PROXY_COMPATIBILITY=true"
-      - DB_NAME=${DB_NAME}
-      - DB_USER=${DB_USER}
-      - DB_PASSWORD=${DB_PASSWORD}
-      - DB_PORT=${DB_PORT}
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:${DB_PORT}/${DB_NAME}
-      - SPRING_DATASOURCE_USERNAME=${DB_USER}
-      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
-      - SPRING_REDIS_HOST=redis
     depends_on:
       - db
       - redis

--- a/src/main/java/com/kefa/api/controller/AccountController.java
+++ b/src/main/java/com/kefa/api/controller/AccountController.java
@@ -1,9 +1,11 @@
 package com.kefa.api.controller;
 
+import com.kefa.api.dto.AccountUpdateRequestDto;
 import com.kefa.api.dto.request.AccountLoginRequestDto;
 import com.kefa.api.dto.request.AccountSignupRequestDto;
 import com.kefa.api.dto.response.AccountResponseDto;
 import com.kefa.api.dto.response.AccountSignupResponseDto;
+import com.kefa.api.dto.response.AccountUpdateResponseDto;
 import com.kefa.api.dto.response.TokenResponse;
 import com.kefa.application.service.AccountService;
 import com.kefa.common.response.ApiResponse;
@@ -23,6 +25,12 @@ import java.util.UUID;
 public class AccountController {
 
     private final AccountService accountService;
+
+    @PutMapping("/account/{id}")
+    public ApiResponse<AccountUpdateResponseDto> updateAccount(@PathVariable String id, @RequestBody @Valid AccountUpdateRequestDto accountUpdateRequestDto, Authentication authentication){
+        AuthenticationInfo authenticationInfo = AuthenticationInfo.from(authentication);
+        return ApiResponse.success(accountService.updateAccount(Long.valueOf(id), accountUpdateRequestDto, authenticationInfo));
+    }
 
     @GetMapping("/account/{id}")
     public ApiResponse<AccountResponseDto> getAccount(@PathVariable Long id, Authentication authentication) {

--- a/src/main/java/com/kefa/api/dto/AccountUpdateRequestDto.java
+++ b/src/main/java/com/kefa/api/dto/AccountUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.kefa.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class AccountUpdateRequestDto {
+
+    @NotBlank(message = "공백은 불가능합니다.")
+    private String name;
+
+}

--- a/src/main/java/com/kefa/api/dto/response/AccountUpdateResponseDto.java
+++ b/src/main/java/com/kefa/api/dto/response/AccountUpdateResponseDto.java
@@ -1,0 +1,32 @@
+package com.kefa.api.dto.response;
+
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.type.SubscriptionType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class AccountUpdateResponseDto {
+
+    private Long id;
+    private String email;
+    private String name;
+    private SubscriptionType subscriptionType;
+    private LocalDateTime updatedAt;
+
+    public static AccountUpdateResponseDto from(Account account) {
+        return AccountUpdateResponseDto.builder()
+            .id(account.getId())
+            .email(account.getEmail())
+            .name(account.getName())
+            .subscriptionType(account.getSubscriptionType())
+            .updatedAt(account.getUpdatedAt())
+            .build();
+    }
+
+}

--- a/src/main/java/com/kefa/application/service/AccountService.java
+++ b/src/main/java/com/kefa/application/service/AccountService.java
@@ -1,15 +1,15 @@
 package com.kefa.application.service;
 
+import com.kefa.api.dto.AccountUpdateRequestDto;
 import com.kefa.api.dto.request.AccountLoginRequestDto;
 import com.kefa.api.dto.request.AccountSignupRequestDto;
-import com.kefa.api.dto.response.AccountSignupResponseDto;
 import com.kefa.api.dto.response.AccountResponseDto;
+import com.kefa.api.dto.response.AccountSignupResponseDto;
+import com.kefa.api.dto.response.AccountUpdateResponseDto;
 import com.kefa.api.dto.response.TokenResponse;
 import com.kefa.application.usecase.AccountUseCase;
 import com.kefa.application.usecase.AuthenticationUseCase;
 import com.kefa.application.usecase.EmailVerificationUseCase;
-import com.kefa.common.exception.AuthenticationException;
-import com.kefa.common.exception.ErrorCode;
 import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +22,10 @@ public class AccountService {
     private final AccountUseCase accountUseCase;
     private final AuthenticationUseCase authenticationUseCase;
     private final EmailVerificationUseCase emailVerificationUseCase;
+
+    public AccountUpdateResponseDto updateAccount(Long targetId, AccountUpdateRequestDto accountUpdateRequestDto, AuthenticationInfo authenticationInfo) {
+        return accountUseCase.updateAccount(targetId, accountUpdateRequestDto, authenticationInfo);
+    }
 
     public AccountResponseDto getAccount(Long targetId, AuthenticationInfo authenticationInfo) {
         return accountUseCase.getAccount(targetId, authenticationInfo);

--- a/src/main/java/com/kefa/application/usecase/AccountUseCase.java
+++ b/src/main/java/com/kefa/application/usecase/AccountUseCase.java
@@ -1,12 +1,16 @@
 package com.kefa.application.usecase;
 
+import com.kefa.api.dto.AccountUpdateRequestDto;
 import com.kefa.api.dto.response.AccountResponseDto;
+import com.kefa.api.dto.response.AccountUpdateResponseDto;
 import com.kefa.common.exception.AuthenticationException;
 import com.kefa.common.exception.ErrorCode;
+import com.kefa.domain.entity.Account;
 import com.kefa.infrastructure.repository.AccountRepository;
 import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,15 +18,27 @@ public class AccountUseCase {
 
     private final AccountRepository accountRepository;
 
+    @Transactional
+    public AccountUpdateResponseDto updateAccount(Long targetId, AccountUpdateRequestDto accountUpdateRequestDto, AuthenticationInfo authenticationInfo) {
+        validateAccountAccess(targetId, authenticationInfo.getId());
+        Account account = getAccount(targetId);
+        account.updateName(accountUpdateRequestDto.getName());
+        return AccountUpdateResponseDto.from(account);
+    }
+
+    @Transactional(readOnly = true)
     public AccountResponseDto getAccount(Long targetId, AuthenticationInfo authenticationInfo) {
         validateAccountAccess(targetId, authenticationInfo.getId());
-        return AccountResponseDto.from(accountRepository.findById(targetId).orElseThrow(() -> new AuthenticationException(ErrorCode.ACCOUNT_NOT_FOUND)));
+        return AccountResponseDto.from(getAccount(targetId));
+    }
+
+    private Account getAccount(Long targetId) {
+        return accountRepository.findById(targetId).orElseThrow(() -> new AuthenticationException(ErrorCode.ACCOUNT_NOT_FOUND));
     }
 
     private void validateAccountAccess(Long targetId, Long loginUserId) {
-        if(!targetId.equals(loginUserId)){
+        if (!targetId.equals(loginUserId)) {
             throw new AuthenticationException(ErrorCode.ACCESS_DENIED);
         }
     }
-
 }

--- a/src/main/java/com/kefa/domain/entity/Account.java
+++ b/src/main/java/com/kefa/domain/entity/Account.java
@@ -88,4 +88,8 @@ public class Account {
         this.emailVerified = true;
     }
 
+    public void updateName(String name){
+        this.name = name;
+    }
+
 }

--- a/src/test/java/com/kefa/application/usecase/AccountUseCaseTest.java
+++ b/src/test/java/com/kefa/application/usecase/AccountUseCaseTest.java
@@ -1,12 +1,15 @@
 package com.kefa.application.usecase;
 
 
+import com.kefa.api.dto.AccountUpdateRequestDto;
 import com.kefa.api.dto.response.AccountResponseDto;
+import com.kefa.api.dto.response.AccountUpdateResponseDto;
 import com.kefa.common.exception.AuthenticationException;
 import com.kefa.common.exception.ErrorCode;
 import com.kefa.domain.entity.Account;
 import com.kefa.infrastructure.repository.AccountRepository;
 import com.kefa.infrastructure.security.auth.AuthenticationInfo;
+import jakarta.validation.ValidationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AccountUseCaseTest {
@@ -40,6 +44,75 @@ public class AccountUseCaseTest {
             .email("test@test.com")
             .name("test")
             .build();
+    }
+
+    @DisplayName("회원 정보 수정 성공 - 본인")
+    @Test
+    void updateAccountSuccess() {
+        // given
+        Long targetId = 1L;
+        String newName = "updatedName";
+        AccountUpdateRequestDto request = new AccountUpdateRequestDto(newName);
+        AuthenticationInfo authInfo = AuthenticationInfo.builder()
+            .id(targetId)
+            .build();
+
+        given(accountRepository.findById(targetId)).willReturn(Optional.of(account));
+
+        // when
+        AccountUpdateResponseDto result = accountUseCase.updateAccount(
+            targetId,
+            request,
+            authInfo
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(targetId);
+        assertThat(result.getName()).isEqualTo(newName);
+        assertThat(result.getEmail()).isEqualTo(account.getEmail());
+        verify(accountRepository, times(1)).findById(targetId);
+    }
+
+    @DisplayName("회원 정보 수정 실패 - 권한 없음")
+    @Test
+    void updateAccountFailAccessDenied() {
+        // given
+        Long targetId = 1L;
+        Long id = 2L;
+        AccountUpdateRequestDto request = new AccountUpdateRequestDto("newName");
+        AuthenticationInfo authInfo = AuthenticationInfo.builder()
+            .id(id)
+            .build();
+
+        // when & then
+        assertThatThrownBy(() ->
+            accountUseCase.updateAccount(targetId, request, authInfo)
+        )
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessage(ErrorCode.ACCESS_DENIED.getMessage());
+        verify(accountRepository, never()).findById(any());
+    }
+
+    @DisplayName("회원 정보 수정 실패 - 계정 없음")
+    @Test
+    void updateAccountFailAccountNotFound() {
+        // given
+        Long targetId = 1L;
+        AccountUpdateRequestDto request = new AccountUpdateRequestDto("newName");
+        AuthenticationInfo authInfo = AuthenticationInfo.builder()
+            .id(targetId)
+            .build();
+
+        given(accountRepository.findById(targetId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+            accountUseCase.updateAccount(targetId, request, authInfo)
+        )
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessage(ErrorCode.ACCOUNT_NOT_FOUND.getMessage());
+        verify(accountRepository, times(1)).findById(targetId);
     }
 
     @DisplayName("회원 조회 성공 - 본인")
@@ -64,9 +137,9 @@ public class AccountUseCaseTest {
 
     }
 
-    @DisplayName("")
+    @DisplayName("회원 조회 실패 - 권한 없음")
     @Test
-    void getAccountFai_AccessDenied() {
+    void getAccountFailAccessDenied() {
 
         //given
         Long targetId = 2L;
@@ -81,7 +154,7 @@ public class AccountUseCaseTest {
 
     }
 
-    @DisplayName("")
+    @DisplayName("회원 조회 실패 - 계정 없음")
     @Test
     void getAccountFailAccountNotFound() {
 


### PR DESCRIPTION
## 📎 Issue
#23 

## 💫 작업 내용
### 구현 기능
1. 회원 정보 수정


### 주요 변경사항
1. 회원 이름 수정 기능
2. 본인 정보만 수정 가능하도록 권한 검증
3. 수정된 정보 응답
4. docker-compose 파일에 환경 변수 주입 방식 수정

## 🔍 테스트
- [x] 회원 정보 수정 성공 테스트
- [x] 권한 없는 사용자 수정 시도 테스트
- [x] 존재하지 않는 계정 수정 시도 테스트

## ✅ 체크리스트
- [x] 변경 사항에 대한 테스트를 진행했습니다
- [x] 불필요한 코드가 없습니다