### PR TITLE
feat: 회사 등록, 수정 조회 기능 추가

### DIFF
--- a/src/main/java/com/kefa/api/controller/CompanyController.java
+++ b/src/main/java/com/kefa/api/controller/CompanyController.java
@@ -3,6 +3,7 @@ package com.kefa.api.controller;
 import com.kefa.api.dto.company.request.BusinessNumberValidateRequest;
 import com.kefa.api.dto.company.request.CompanyAddRequest;
 import com.kefa.api.dto.company.response.CompanyAddResponse;
+import com.kefa.api.dto.company.response.CompanyResponse;
 import com.kefa.infrastructure.client.nts.BusinessNoValidateResponse;
 import com.kefa.application.service.CompanyService;
 import com.kefa.common.response.ApiResponse;
@@ -10,15 +11,25 @@ import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class CompanyController {
 
     private final CompanyService companyService;
+
+    @GetMapping("/companies/{companyId}")
+    public ApiResponse<CompanyResponse> getCompany(@PathVariable Long companyId, Authentication authentication) {
+        return ApiResponse.success(companyService.getMyCompany(companyId, AuthenticationInfo.from(authentication)));
+    }
+
+    @GetMapping("/companies")
+    public ApiResponse<List<CompanyResponse>> getCompanies(Authentication authentication) {
+        return ApiResponse.success(companyService.getMyCompanies(AuthenticationInfo.from(authentication)));
+    }
 
     @PostMapping("/companies")
     public ApiResponse<CompanyAddResponse> add(@RequestBody @Valid CompanyAddRequest companyAddRequest, Authentication authentication) {

--- a/src/main/java/com/kefa/api/controller/CompanyController.java
+++ b/src/main/java/com/kefa/api/controller/CompanyController.java
@@ -1,11 +1,15 @@
 package com.kefa.api.controller;
 
 import com.kefa.api.dto.company.request.BusinessNumberValidateRequest;
+import com.kefa.api.dto.company.request.CompanyAddRequest;
+import com.kefa.api.dto.company.response.CompanyAddResponse;
 import com.kefa.infrastructure.client.nts.BusinessNoValidateResponse;
 import com.kefa.application.service.CompanyService;
 import com.kefa.common.response.ApiResponse;
+import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,6 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class CompanyController {
 
     private final CompanyService companyService;
+
+    @PostMapping("/companies")
+    public ApiResponse<CompanyAddResponse> add(@RequestBody @Valid CompanyAddRequest companyAddRequest, Authentication authentication) {
+        return ApiResponse.success(companyService.add(companyAddRequest, AuthenticationInfo.from(authentication)));
+    }
 
     @PostMapping("/companies/validate-business-number")
     public ApiResponse<BusinessNoValidateResponse> validateBusinessNumber(@RequestBody @Valid BusinessNumberValidateRequest request) {

--- a/src/main/java/com/kefa/api/controller/CompanyController.java
+++ b/src/main/java/com/kefa/api/controller/CompanyController.java
@@ -2,6 +2,7 @@ package com.kefa.api.controller;
 
 import com.kefa.api.dto.company.request.BusinessNumberValidateRequest;
 import com.kefa.api.dto.company.request.CompanyAddRequest;
+import com.kefa.api.dto.company.request.CompanyUpdateRequest;
 import com.kefa.api.dto.company.response.CompanyAddResponse;
 import com.kefa.api.dto.company.response.CompanyResponse;
 import com.kefa.infrastructure.client.nts.BusinessNoValidateResponse;
@@ -20,6 +21,13 @@ import java.util.List;
 public class CompanyController {
 
     private final CompanyService companyService;
+
+
+
+    @PutMapping("/company")
+    public ApiResponse<CompanyResponse> updateCompany(@RequestBody @Valid CompanyUpdateRequest request, Authentication authentication){
+        return ApiResponse.success(companyService.updateCompany(request, AuthenticationInfo.from(authentication)));
+    }
 
     @GetMapping("/companies/{companyId}")
     public ApiResponse<CompanyResponse> getCompany(@PathVariable Long companyId, Authentication authentication) {

--- a/src/main/java/com/kefa/api/dto/company/request/BusinessNumberValidateRequest.java
+++ b/src/main/java/com/kefa/api/dto/company/request/BusinessNumberValidateRequest.java
@@ -1,6 +1,7 @@
 package com.kefa.api.dto.company.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class BusinessNumberValidateRequest {
 
-    @NotBlank(message = "사업자 등록 번호는 필수입니다.")
+    @NotBlank(message = "사업자번호는 필수입니다")
+    @Pattern(regexp = "^[0-9]{10}$", message = "사업자번호는 10자리 숫자여야 합니다")
     private String b_no;
 
 }

--- a/src/main/java/com/kefa/api/dto/company/request/CompanyAddRequest.java
+++ b/src/main/java/com/kefa/api/dto/company/request/CompanyAddRequest.java
@@ -19,7 +19,8 @@ public class CompanyAddRequest {
     @NotBlank(message = "회사명은 필수입니다.")
     private String name;
 
-    @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "올바른 사업자등록번호 형식이 아닙니다.")
+    @NotBlank(message = "사업자번호는 필수입니다")
+    @Pattern(regexp = "^[0-9]{10}$", message = "사업자번호는 10자리 숫자여야 합니다")
     private String businessNumber;
 
     @NotBlank(message = "주소는 필수입니다.")

--- a/src/main/java/com/kefa/api/dto/company/request/CompanyAddRequest.java
+++ b/src/main/java/com/kefa/api/dto/company/request/CompanyAddRequest.java
@@ -1,0 +1,45 @@
+package com.kefa.api.dto.company.request;
+
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.entity.Company;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CompanyAddRequest {
+
+    @NotBlank(message = "회사명은 필수입니다.")
+    private String name;
+
+    @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "올바른 사업자등록번호 형식이 아닙니다.")
+    private String businessNumber;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    private String address;
+
+    @NotBlank(message = "업종은 필수입니다.")
+    private String industry;
+
+    @PositiveOrZero(message = "매출액은 0 이상이어야 합니다.")
+    private Long revenueMillion;
+
+    public static Company toEntity(CompanyAddRequest request, Account account) {
+        return Company.builder()
+            .account(account)
+            .name(request.getName())
+            .businessNumber(request.getBusinessNumber())
+            .address(request.getAddress())
+            .industry(request.getIndustry())
+            .revenueMillion(request.getRevenueMillion())
+            .build();
+    }
+
+}

--- a/src/main/java/com/kefa/api/dto/company/request/CompanyUpdateRequest.java
+++ b/src/main/java/com/kefa/api/dto/company/request/CompanyUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.kefa.api.dto.company.request;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CompanyUpdateRequest {
+
+    @NotNull
+    private Long id;
+
+    @NotBlank(message = "회사명은 필수입니다")
+    private String name;
+
+    @NotBlank(message = "주소는 필수입니다")
+    private String address;
+
+    @NotBlank(message = "업종은 필수입니다")
+    private String industry;
+
+    @PositiveOrZero(message = "매출액은 0 이상이어야 합니다.")
+    private Long revenueMillion;
+
+}

--- a/src/main/java/com/kefa/api/dto/company/response/CompanyAddResponse.java
+++ b/src/main/java/com/kefa/api/dto/company/response/CompanyAddResponse.java
@@ -1,0 +1,33 @@
+package com.kefa.api.dto.company.response;
+
+import com.kefa.domain.entity.Company;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyAddResponse {
+
+    private Long id;
+    private String name;
+    private String businessNumber;
+    private String address;
+    private String industry;
+    private Long revenueMillion;
+
+    public static CompanyAddResponse from(Company company) {
+        return CompanyAddResponse.builder()
+            .id(company.getId())
+            .name(company.getName())
+            .businessNumber(company.getBusinessNumber())
+            .address(company.getAddress())
+            .industry(company.getIndustry())
+            .revenueMillion(company.getRevenueMillion())
+            .build();
+    }
+
+}

--- a/src/main/java/com/kefa/api/dto/company/response/CompanyResponse.java
+++ b/src/main/java/com/kefa/api/dto/company/response/CompanyResponse.java
@@ -1,0 +1,30 @@
+package com.kefa.api.dto.company.response;
+
+import com.kefa.domain.entity.Company;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CompanyResponse {
+
+    private Long id;
+    private String name;
+    private String businessNumber;
+    private String address;
+    private String industry;
+    private Long revenueMillion;
+    private String status;
+
+    public static CompanyResponse from(Company company) {
+        return CompanyResponse.builder()
+            .id(company.getId())
+            .name(company.getName())
+            .businessNumber(company.getBusinessNumber())
+            .address(company.getAddress())
+            .industry(company.getIndustry())
+            .revenueMillion(company.getRevenueMillion())
+            .build();
+    }
+
+}

--- a/src/main/java/com/kefa/application/service/CompanyService.java
+++ b/src/main/java/com/kefa/application/service/CompanyService.java
@@ -1,9 +1,12 @@
 package com.kefa.application.service;
 
 import com.kefa.api.dto.company.request.BusinessNumberValidateRequest;
-import com.kefa.infrastructure.client.nts.BusinessNoValidateResponse;
+import com.kefa.api.dto.company.request.CompanyAddRequest;
+import com.kefa.api.dto.company.response.CompanyAddResponse;
 import com.kefa.application.usecase.CompanyUseCase;
+import com.kefa.infrastructure.client.nts.BusinessNoValidateResponse;
 import com.kefa.infrastructure.client.nts.ValidationBusinessNumberClient;
+import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +16,10 @@ public class CompanyService {
 
     private final CompanyUseCase companyUseCase;
     private final ValidationBusinessNumberClient client;
+
+    public CompanyAddResponse add(CompanyAddRequest companyAddRequest, AuthenticationInfo authenticationInfo) {
+        return companyUseCase.add(companyAddRequest, authenticationInfo);
+    }
 
     public BusinessNoValidateResponse validateBusinessNumber(BusinessNumberValidateRequest request) {
         BusinessNoValidateResponse ntsApiResponse = client.validateBusinessNumber(request);

--- a/src/main/java/com/kefa/application/service/CompanyService.java
+++ b/src/main/java/com/kefa/application/service/CompanyService.java
@@ -3,6 +3,7 @@ package com.kefa.application.service;
 import com.kefa.api.dto.company.request.BusinessNumberValidateRequest;
 import com.kefa.api.dto.company.request.CompanyAddRequest;
 import com.kefa.api.dto.company.response.CompanyAddResponse;
+import com.kefa.api.dto.company.response.CompanyResponse;
 import com.kefa.application.usecase.CompanyUseCase;
 import com.kefa.infrastructure.client.nts.BusinessNoValidateResponse;
 import com.kefa.infrastructure.client.nts.ValidationBusinessNumberClient;
@@ -10,12 +11,22 @@ import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class CompanyService {
 
     private final CompanyUseCase companyUseCase;
     private final ValidationBusinessNumberClient client;
+
+    public CompanyResponse getMyCompany(Long targetId, AuthenticationInfo from) {
+        return companyUseCase.getMyCompany(targetId, from);
+    }
+
+    public List<CompanyResponse> getMyCompanies(AuthenticationInfo authenticationInfo) {
+        return companyUseCase.getMyCompanies(authenticationInfo);
+    }
 
     public CompanyAddResponse add(CompanyAddRequest companyAddRequest, AuthenticationInfo authenticationInfo) {
         return companyUseCase.add(companyAddRequest, authenticationInfo);

--- a/src/main/java/com/kefa/application/service/CompanyService.java
+++ b/src/main/java/com/kefa/application/service/CompanyService.java
@@ -2,9 +2,11 @@ package com.kefa.application.service;
 
 import com.kefa.api.dto.company.request.BusinessNumberValidateRequest;
 import com.kefa.api.dto.company.request.CompanyAddRequest;
+import com.kefa.api.dto.company.request.CompanyUpdateRequest;
 import com.kefa.api.dto.company.response.CompanyAddResponse;
 import com.kefa.api.dto.company.response.CompanyResponse;
 import com.kefa.application.usecase.CompanyUseCase;
+import com.kefa.common.response.ApiResponse;
 import com.kefa.infrastructure.client.nts.BusinessNoValidateResponse;
 import com.kefa.infrastructure.client.nts.ValidationBusinessNumberClient;
 import com.kefa.infrastructure.security.auth.AuthenticationInfo;
@@ -19,6 +21,10 @@ public class CompanyService {
 
     private final CompanyUseCase companyUseCase;
     private final ValidationBusinessNumberClient client;
+
+    public CompanyResponse updateCompany(CompanyUpdateRequest request, AuthenticationInfo authenticationInfo) {
+        return companyUseCase.update(request, authenticationInfo);
+    }
 
     public CompanyResponse getMyCompany(Long targetId, AuthenticationInfo from) {
         return companyUseCase.getMyCompany(targetId, from);

--- a/src/main/java/com/kefa/application/usecase/CompanyUseCase.java
+++ b/src/main/java/com/kefa/application/usecase/CompanyUseCase.java
@@ -1,10 +1,17 @@
 package com.kefa.application.usecase;
 
+import com.kefa.api.dto.company.request.CompanyAddRequest;
+import com.kefa.api.dto.company.response.CompanyAddResponse;
+import com.kefa.common.exception.AuthenticationException;
 import com.kefa.common.exception.ErrorCode;
 import com.kefa.common.exception.NtsException;
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.entity.Company;
 import com.kefa.infrastructure.client.nts.BusinessNoValidateResponse;
 import com.kefa.infrastructure.client.nts.BusinessStatusData;
+import com.kefa.infrastructure.repository.AccountRepository;
 import com.kefa.infrastructure.repository.CompanyRepository;
+import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +20,17 @@ import org.springframework.stereotype.Service;
 public class CompanyUseCase {
 
     private final CompanyRepository companyRepository;
+    private final AccountRepository accountRepository;
 
+    public CompanyAddResponse add(CompanyAddRequest request, AuthenticationInfo authenticationInfo) {
+
+        Account account = accountRepository.findById(authenticationInfo.getId()).orElseThrow(() -> new AuthenticationException(ErrorCode.ACCOUNT_NOT_FOUND));
+        Company company = CompanyAddRequest.toEntity(request, account);
+
+        companyRepository.save(company);
+
+        return CompanyAddResponse.from(company);
+    }
 
     public void validateBusinessNumber(BusinessNoValidateResponse ntsApiResponse) {
 
@@ -33,7 +50,7 @@ public class CompanyUseCase {
 
     private void validateBusinessNumberActive(BusinessStatusData data) {
 
-        if(data.isNotRegistered()) {
+        if (data.isNotRegistered()) {
             throw new NtsException(ErrorCode.BUSINESS_NUMBER_NOT_FOUND);
         }
 
@@ -42,5 +59,4 @@ public class CompanyUseCase {
         }
 
     }
-
 }

--- a/src/main/java/com/kefa/common/exception/ErrorCode.java
+++ b/src/main/java/com/kefa/common/exception/ErrorCode.java
@@ -9,7 +9,7 @@ public enum ErrorCode {
 
     //회사 관련
     COMPANY_NOT_FOUND(404, "회사를 찾을 수 없습니다"),
-    NOT_COMPANY_OWNER(400, "본인 회사만 조회 할 수 있습니다"),
+    NOT_COMPANY_OWNER(400, "본인 회사만 가능합니다"),
 
     //NTS API 관런
     NTS_PARSING_ERROR(500, "국세청 API 응답 파싱 중 오류가 발생했습니다"),

--- a/src/main/java/com/kefa/common/exception/ErrorCode.java
+++ b/src/main/java/com/kefa/common/exception/ErrorCode.java
@@ -7,6 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    //회사 관련
+    COMPANY_NOT_FOUND(404, "회사를 찾을 수 없습니다"),
+    NOT_COMPANY_OWNER(400, "본인 회사만 조회 할 수 있습니다"),
+
     //NTS API 관런
     NTS_PARSING_ERROR(500, "국세청 API 응답 파싱 중 오류가 발생했습니다"),
     BUSINESS_NUMBER_NOT_FOUND(404, "존재하지 않는 사업자등록번호입니다"),

--- a/src/main/java/com/kefa/domain/entity/Company.java
+++ b/src/main/java/com/kefa/domain/entity/Company.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
@@ -26,16 +25,16 @@ public class Company extends BaseEntity {
     @Column(unique = true, nullable = false)
     private String name;
 
-    @Column
+    @Column(unique = true, nullable = false)
     private String businessNumber;
 
-    @Column
+    @Column(nullable = false)
     private String address;
 
-    @Column
+    @Column(nullable = false)
     private String industry;
 
-    @Column
+    @Column(nullable = false)
     private Long revenueMillion;
 
 }

--- a/src/main/java/com/kefa/domain/entity/Company.java
+++ b/src/main/java/com/kefa/domain/entity/Company.java
@@ -1,5 +1,6 @@
 package com.kefa.domain.entity;
 
+import com.kefa.api.dto.company.request.CompanyUpdateRequest;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,5 +37,12 @@ public class Company extends BaseEntity {
 
     @Column(nullable = false)
     private Long revenueMillion;
+
+    public void update(CompanyUpdateRequest request) {
+        this.name = request.getName();
+        this.address = request.getAddress();
+        this.industry = request.getIndustry();
+        this.revenueMillion = request.getRevenueMillion();
+    }
 
 }

--- a/src/main/java/com/kefa/infrastructure/repository/CompanyRepository.java
+++ b/src/main/java/com/kefa/infrastructure/repository/CompanyRepository.java
@@ -1,9 +1,20 @@
 package com.kefa.infrastructure.repository;
 
+import com.kefa.api.dto.company.response.CompanyResponse;
 import com.kefa.domain.entity.Company;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface CompanyRepository extends JpaRepository<Company, Long> {
+
+    List<Company> findAllByAccountId(Long id);
+
+    @EntityGraph(attributePaths = "account")
+    Optional<Company> findCompanyById(Long id);
+
 }

--- a/src/test/java/com/kefa/application/usecase/CompanyUseCaseTest.java
+++ b/src/test/java/com/kefa/application/usecase/CompanyUseCaseTest.java
@@ -1,10 +1,16 @@
 package com.kefa.application.usecase;
 
+import com.kefa.api.dto.company.request.CompanyAddRequest;
+import com.kefa.api.dto.company.response.CompanyAddResponse;
+import com.kefa.common.exception.AuthenticationException;
 import com.kefa.common.exception.ErrorCode;
 import com.kefa.common.exception.NtsException;
+import com.kefa.domain.entity.Account;
 import com.kefa.infrastructure.client.nts.BusinessNoValidateResponse;
 import com.kefa.infrastructure.client.nts.BusinessStatusData;
+import com.kefa.infrastructure.repository.AccountRepository;
 import com.kefa.infrastructure.repository.CompanyRepository;
+import com.kefa.infrastructure.security.auth.AuthenticationInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,8 +20,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CompanyUseCaseTest {
@@ -23,8 +33,71 @@ public class CompanyUseCaseTest {
     @Mock
     private CompanyRepository companyRepository;
 
+    @Mock
+    private AccountRepository accountRepository;
+
     @InjectMocks
     private CompanyUseCase companyUseCase;
+
+
+    @Test
+    @DisplayName("회사 등록 성공")
+    void addSuccess() {
+        //given
+        CompanyAddRequest request = CompanyAddRequest.builder()
+            .name("test")
+            .businessNumber("213-854-66870")
+            .address("주소테스트")
+            .industry("업종테스트")
+            .revenueMillion(1000L)
+            .build();
+
+        AuthenticationInfo authenticationInfo = AuthenticationInfo.builder()
+            .id(1L)
+            .build();
+
+        Account account = Account.builder()
+            .id(1L)
+            .build();
+
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+
+        //when
+        CompanyAddResponse response = companyUseCase.add(request, authenticationInfo);
+
+        //then
+        assertNotNull(response);
+        assertThat(response.getName()).isEqualTo("test");
+        assertThat(response.getBusinessNumber()).isEqualTo("213-854-66870");
+        assertThat(response.getAddress()).isEqualTo("주소테스트");
+        assertThat(response.getIndustry()).isEqualTo("업종테스트");
+        assertThat(response.getRevenueMillion()).isEqualTo(1000L);
+    }
+
+    @Test
+    @DisplayName("회사 등록 실패 - 회원이 존재하지 않음")
+    void addFailNotFoundAccount() {
+        //given
+        CompanyAddRequest request = CompanyAddRequest.builder()
+            .name("test")
+            .businessNumber("213-854-66870")
+            .address("주소테스트")
+            .industry("업종테스트")
+            .revenueMillion(1000L)
+            .build();
+
+        AuthenticationInfo authenticationInfo = AuthenticationInfo.builder()
+            .id(1L)
+            .build();
+
+        when(accountRepository.findById(1L)).thenReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> companyUseCase.add(request, authenticationInfo))
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessage(ErrorCode.ACCOUNT_NOT_FOUND.getMessage());
+    }
+
 
     @Test
     @DisplayName("사업자번호가 정상일 경우 성공")


### PR DESCRIPTION
## 📎 Issue
#32 

## 💫 작업 내용
### 구현 기능

- 회사 정보 등록
- 회사 정보 수정
- 자신이 등록한 회사 단일 조회


### 주요 변경사항

- 각 기능들의 성공, 실패 단위 테스트 진행

## 🔍 테스트

- 회사 등록 성공/실패
- 회사 수정 성공/실패
- 회사 조회 성공/실패
- 회사 목록 조회


## ✅ 체크리스트
- [x] 변경 사항에 대한 테스트를 진행했습니다