### PR TITLE
Feature: JWT 기반 토큰 관리 및 로그아웃 기능

### DIFF
--- a/src/main/java/com/kefa/api/controller/AuthController.java
+++ b/src/main/java/com/kefa/api/controller/AuthController.java
@@ -36,7 +36,8 @@ public class AuthController {
     }
 
     @PutMapping("/auth/password")
-    public ApiResponse<AccountUpdatePasswordResponse> updatePassword(@RequestBody @Valid AccountUpdatePasswordRequest accountUpdatePasswordRequest, @AuthenticationPrincipal LoginAccount loginAccount) {
+    public ApiResponse<AccountUpdatePasswordResponse> updatePassword(@RequestBody @Valid AccountUpdatePasswordRequest accountUpdatePasswordRequest,
+                                                                     @AuthenticationPrincipal LoginAccount loginAccount) {
         return ApiResponse.success(authService.updatePassword(accountUpdatePasswordRequest, loginAccount.getId()));
     }
 
@@ -70,12 +71,31 @@ public class AuthController {
         return ApiResponse.success(tokenResponse);
     }
 
+    @PostMapping("/auth/logout")
+    public ApiResponse<?> logout(@AuthenticationPrincipal LoginAccount loginAccount, HttpServletResponse response) {
+
+        authService.logout(loginAccount.getId(), loginAccount.getJwtId());
+        removeTokenCookie(response);
+
+        return ApiResponse.success();
+    }
+
     private void addTokenCookie(HttpServletResponse response, TokenResponse tokenResponse) {
         Cookie accessTokenCookie = new Cookie("accessToken", tokenResponse.getAccessToken());
         accessTokenCookie.setHttpOnly(true);
         accessTokenCookie.setSecure(true);
         accessTokenCookie.setPath("/");
         accessTokenCookie.setMaxAge(3600);
+
+        response.addCookie(accessTokenCookie);
+    }
+
+    private void removeTokenCookie(HttpServletResponse response) {
+        Cookie accessTokenCookie = new Cookie("accessToken", "");
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge(0);
 
         response.addCookie(accessTokenCookie);
     }

--- a/src/main/java/com/kefa/application/service/AuthService.java
+++ b/src/main/java/com/kefa/application/service/AuthService.java
@@ -39,6 +39,10 @@ public class AuthService {
         return authenticationUseCase.login(accountLoginRequest);
     }
 
+    public void logout(Long loginAccountId, String jwtId) {
+        authenticationUseCase.logout(loginAccountId, jwtId);
+    }
+
     @Transactional
     public AccountSignupResponse signup(AccountSignupRequest request) {
 

--- a/src/main/java/com/kefa/application/usecase/AuthenticationUseCase.java
+++ b/src/main/java/com/kefa/application/usecase/AuthenticationUseCase.java
@@ -9,15 +9,13 @@ import com.kefa.api.dto.auth.response.TokenResponse;
 import com.kefa.common.exception.AccountException;
 import com.kefa.common.exception.AuthenticationException;
 import com.kefa.common.exception.ErrorCode;
-import com.kefa.domain.entity.Account;
-import com.kefa.domain.entity.RefreshToken;
 import com.kefa.common.type.LoginType;
 import com.kefa.common.type.Role;
 import com.kefa.common.type.SubscriptionType;
+import com.kefa.domain.entity.Account;
+import com.kefa.domain.entity.RefreshToken;
 import com.kefa.domain.vo.AccountVO;
-import com.kefa.infrastructure.repository.AccountRepository;
-import com.kefa.infrastructure.repository.RefreshTokenRepository;
-import com.kefa.infrastructure.repository.SocialInfoRepository;
+import com.kefa.infrastructure.repository.*;
 import com.kefa.infrastructure.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -40,13 +38,15 @@ public class AuthenticationUseCase {
     private final AccountRepository accountRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final SocialInfoRepository socialInfoRepository;
+    private final ActiveTokenRepository activeTokenRepository;
+    private final BlackListRepository blackListRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
 
     public TokenResponse refreshToken(String refreshToken, String deviceId) {
 
         Long id = jwtProvider.getId(refreshToken);
-        Account account = accountRepository.findByIdWithRefreshToken(id).orElseThrow(() -> new AuthenticationException(ErrorCode.NOT_FOUND_ACCOUNT));
+        Account account = getAccountWithRefreshTokenFromAccountId(id);
         RefreshToken savedRefreshToken = account.getRefreshToken();
 
         validateRefreshToken(savedRefreshToken, refreshToken);
@@ -117,9 +117,30 @@ public class AuthenticationUseCase {
             account.addRefreshToken(refreshToken);
         }
 
+        String jwtId = jwtProvider.getJwtId(tokenResponse.getAccessToken());
+        activeTokenRepository.save(account.getId(), jwtId);
+
         refreshTokenRepository.save(refreshToken);
 
         return tokenResponse;
+    }
+
+    @Transactional
+    public void logout(Long loginAccountId, String jwtId) {
+
+        Account account = getAccountWithRefreshTokenFromAccountId(loginAccountId);
+
+        activeTokenRepository.delete(account.getId(), jwtId);
+        blackListRepository.save(jwtId);
+        RefreshToken refreshToken = account.getRefreshToken();
+
+        if (refreshToken != null) {
+
+            account.removeRefreshToken(refreshToken);
+            refreshTokenRepository.delete(refreshToken);
+
+        }
+
     }
 
     public AccountSignupResponse signup(AccountSignupRequest request) {
@@ -129,6 +150,10 @@ public class AuthenticationUseCase {
 
         return AccountSignupResponse.from(account);
 
+    }
+
+    private Account getAccountWithRefreshTokenFromAccountId(Long accountId) {
+        return accountRepository.findByIdWithRefreshToken(accountId).orElseThrow(() -> new AuthenticationException(ErrorCode.NOT_FOUND_ACCOUNT));
     }
 
     private void validateDeviceId(String deviceId, String requestDeviceId) {

--- a/src/main/java/com/kefa/common/exception/ErrorCode.java
+++ b/src/main/java/com/kefa/common/exception/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
     NTS_HTTP_ERROR(503, "국세청 API 통신 중 오류가 발생했습니다"),
 
     //인증, 회원 관련,
+    BLACKLISTED_TOKEN(401, "블랙리스트에 등록된 토큰입니다 다시 로그인해주세요"),
     INVALID_DEVICE_ID(400, "디바이스 아이디가 올바르지 않습니다 다시 로그인하시길 바랍니다"),
     MISSING_USER_AGENT(400, "요청 헤더 User-Agent를 찾을 수 없습니다"),
     NOT_FOUND_SOCIAL_INFO(404, "통합된 소셜 계정 정보가 존재하지 않습니다"),

--- a/src/main/java/com/kefa/domain/entity/Account.java
+++ b/src/main/java/com/kefa/domain/entity/Account.java
@@ -55,6 +55,11 @@ public class Account extends BaseEntity {
         refreshToken.addAccount(this);
     }
 
+    public void removeRefreshToken(RefreshToken refreshToken) {
+        this.refreshToken = null;
+        refreshToken.removeAccount();
+    }
+
     public void addSocialInfo(SocialInfo socialInfo) {
         this.socialInfos.add(socialInfo);
     }

--- a/src/main/java/com/kefa/domain/entity/RefreshToken.java
+++ b/src/main/java/com/kefa/domain/entity/RefreshToken.java
@@ -42,6 +42,10 @@ public class RefreshToken {
         this.account = account;
     }
 
+    public void removeAccount() {
+        this.account = null;
+    }
+
     public void updateToken(String token, LocalDateTime expiresAt) {
         this.token = token;
         this.expiresAt = expiresAt;

--- a/src/main/java/com/kefa/infrastructure/cache/CacheConfig.java
+++ b/src/main/java/com/kefa/infrastructure/cache/CacheConfig.java
@@ -2,19 +2,40 @@ package com.kefa.infrastructure.cache;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class CacheConfig {
 
+    @Value("${jwt.access-expiration-time}")
+    private long accessExpirationTime;
+
     @Bean
     public Cache<String, String> emailVerificationCache() {
         return Caffeine.newBuilder()
             .expireAfterWrite(10, TimeUnit.MINUTES)
-            .maximumSize(200)
+            .maximumSize(2000L)
+            .build();
+    }
+
+    @Bean
+    public Cache<Long, Set<String>> activeTokensCache() {
+        return Caffeine.newBuilder()
+            .expireAfterWrite(accessExpirationTime, TimeUnit.MILLISECONDS)
+            .maximumSize(100000L)
+            .build();
+    }
+
+    @Bean
+    public Cache<String, Boolean> blackListCache() {
+        return Caffeine.newBuilder()
+            .expireAfterWrite(accessExpirationTime, TimeUnit.MILLISECONDS)
+            .maximumSize(100000L)
             .build();
     }
 

--- a/src/main/java/com/kefa/infrastructure/repository/ActiveTokenRepository.java
+++ b/src/main/java/com/kefa/infrastructure/repository/ActiveTokenRepository.java
@@ -18,7 +18,14 @@ public class ActiveTokenRepository {
     }
 
     public void delete(Long accountId, String jwtId) {
-        findByAccountId(accountId).remove(jwtId);
+
+        Set<String> activeJwtIds = findByAccountId(accountId);
+        activeJwtIds.remove(jwtId);
+
+        if(activeJwtIds.isEmpty()) {
+            activeTokensCache.invalidate(accountId);
+        }
+
     }
 
     public Set<String> findByAccountId(Long accountId) {

--- a/src/main/java/com/kefa/infrastructure/repository/ActiveTokenRepository.java
+++ b/src/main/java/com/kefa/infrastructure/repository/ActiveTokenRepository.java
@@ -1,0 +1,32 @@
+package com.kefa.infrastructure.repository;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+@RequiredArgsConstructor
+public class ActiveTokenRepository {
+
+    private final Cache<Long, Set<String>> activeTokensCache;
+
+    public void save(Long accountId, String jwtId) {
+        findByAccountId(accountId).add(jwtId);
+    }
+
+    public void delete(Long accountId, String jwtId) {
+        findByAccountId(accountId).remove(jwtId);
+    }
+
+    public Set<String> findByAccountId(Long accountId) {
+        return activeTokensCache.get(accountId, k -> ConcurrentHashMap.newKeySet());
+    }
+
+    public void invalidateAccountAllActiveTokens(Long accountId) {
+        activeTokensCache.invalidate(accountId);
+    }
+
+}

--- a/src/main/java/com/kefa/infrastructure/repository/BlackListRepository.java
+++ b/src/main/java/com/kefa/infrastructure/repository/BlackListRepository.java
@@ -1,0 +1,29 @@
+package com.kefa.infrastructure.repository;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class BlackListRepository {
+
+    private final Cache<String, Boolean> blackListCache;
+
+    public void save(String jwtId) {
+        blackListCache.put(jwtId, true);
+    }
+
+    public void saveAll(Set<String> jwtIds) {
+        for (String jwtId : jwtIds) {
+            blackListCache.put(jwtId, true);
+        }
+    }
+
+    public boolean isBlacklisted(String jwtId) {
+        return blackListCache.getIfPresent(jwtId) != null;
+    }
+
+}

--- a/src/main/java/com/kefa/infrastructure/security/auth/LoginAccount.java
+++ b/src/main/java/com/kefa/infrastructure/security/auth/LoginAccount.java
@@ -13,12 +13,14 @@ public class LoginAccount {
     private Long id;
     private Role role;
     private String name;
+    private String jwtId;
 
-    public static LoginAccount of(final Long id, final Role role, final String name) {
+    public static LoginAccount of(final Long id, final Role role, final String name, final String jwtId) {
         return LoginAccount.builder()
             .id(id)
             .role(role)
             .name(name)
+            .jwtId(jwtId)
             .build();
     }
 

--- a/src/main/java/com/kefa/infrastructure/security/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kefa/infrastructure/security/auth/OAuth2SuccessHandler.java
@@ -7,6 +7,7 @@ import com.kefa.domain.entity.Account;
 import com.kefa.domain.entity.RefreshToken;
 import com.kefa.common.type.Role;
 import com.kefa.infrastructure.repository.AccountRepository;
+import com.kefa.infrastructure.repository.ActiveTokenRepository;
 import com.kefa.infrastructure.security.jwt.JwtProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,6 +31,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JwtProvider jwtProvider;
     private final AccountRepository accountRepository;
+    private final ActiveTokenRepository activeTokenRepository;
 
     @Value("${oauth2.main-page-uri}")
     private String mainPageUri;
@@ -62,6 +64,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 refreshToken = createRefreshTokenEntity(account, deviceId, tokenResponse.getRefreshToken());
                 account.addRefreshToken(refreshToken);
             }
+
+            String jwtId = jwtProvider.getJwtId(tokenResponse.getAccessToken());
+            activeTokenRepository.save(account.getId(), jwtId);
 
             getRedirectStrategy().sendRedirect(request, response, mainPageUri);
 

--- a/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/com/kefa/infrastructure/security/config/SecurityConfig.java
@@ -45,7 +45,14 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/**", "/index/**", "/oauth2/**").permitAll()
+                .requestMatchers(
+                    "/auth/login",
+                    "/auth/signup",
+                    "/auth/email-verify",
+                    "/auth/email-verify/resend",
+                    "/auth/token/refresh",
+                    "/oauth2/**"
+                ).permitAll()
                 .anyRequest().authenticated()
             )
             .exceptionHandling(exception -> exception

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,9 @@
 package com.kefa.infrastructure.security.jwt;
 
+import com.kefa.common.exception.AuthenticationException;
+import com.kefa.common.exception.ErrorCode;
 import com.kefa.common.type.Role;
+import com.kefa.infrastructure.repository.BlackListRepository;
 import com.kefa.infrastructure.security.auth.JwtAuthenticationToken;
 import com.kefa.infrastructure.security.auth.LoginAccount;
 import jakarta.servlet.FilterChain;
@@ -8,6 +11,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -25,16 +29,24 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final BlackListRepository blackListRepository;
+
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    protected void doFilterInternal(@NonNull HttpServletRequest request,@NonNull HttpServletResponse response,@NonNull FilterChain filterChain)
 
         throws ServletException, IOException {
         String token = getTokenFromRequest(request);
 
         if (StringUtils.hasText(token) && jwtProvider.validateToken(token)) {
+            String jwtId = jwtProvider.getJwtId(token);
+
+            if (blackListRepository.isBlacklisted(jwtId)) {
+                throw new AuthenticationException(ErrorCode.BLACKLISTED_TOKEN);
+            }
+
             Authentication authentication = createAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
@@ -48,7 +60,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Long id = jwtProvider.getId(token);
         Role role = jwtProvider.getRole(token);
         String name = jwtProvider.getName(token);
-        LoginAccount loginAccount = LoginAccount.of(id, role, name);
+        String jwtId = jwtProvider.getJwtId(token);
+        LoginAccount loginAccount = LoginAccount.of(id, role, name, jwtId);
         Collection<GrantedAuthority> authorities = createAuthorities(role);
 
         return new JwtAuthenticationToken(loginAccount, " ", authorities);

--- a/src/main/java/com/kefa/infrastructure/security/jwt/JwtProvider.java
+++ b/src/main/java/com/kefa/infrastructure/security/jwt/JwtProvider.java
@@ -17,11 +17,16 @@ import javax.crypto.SecretKey;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.UUID;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtProvider {
+
+    private static final String CLAIM_ROLE_SUBJECT = "role";
+    private static final String CLAIM_NAME_SUBJECT = "name";
+    private static final String CLAIM_JWT_ID_SUBJECT = "jwtId";
 
     private final JwtProperties jwtProperties;
     private final CipherService cipherService;
@@ -29,13 +34,11 @@ public class JwtProvider {
 
     @PostConstruct
     public void init() {
-
         byte[] keyByte = Decoders.BASE64.decode(jwtProperties.getKey());
         this.key = Keys.hmacShaKeyFor(keyByte);
-
     }
 
-    private String createToken(Long id, Role role, String name, long expirationTime) {
+    private String createToken(Long id, Role role, String name, long expirationTime, boolean includeJwtId) {
 
         Date nowDate = new Date();
         Date expirationDate = new Date(nowDate.getTime() + expirationTime);
@@ -44,23 +47,31 @@ public class JwtProvider {
         String encryptedRole = cipherService.encrypt(String.valueOf(role));
         String encryptedName = cipherService.encrypt(name);
 
-        return Jwts.builder()
+
+        JwtBuilder jwtBuilder = Jwts.builder()
             .subject(encryptedId)
-            .claim("role", encryptedRole)
-            .claim("name", encryptedName)
+            .claim(CLAIM_ROLE_SUBJECT, encryptedRole)
+            .claim(CLAIM_NAME_SUBJECT, encryptedName)
+
             .issuedAt(nowDate)
             .expiration(expirationDate)
-            .signWith(key)
-            .compact();
+            .signWith(key);
+
+        if(includeJwtId) {
+            String encryptedJwtId = cipherService.encrypt(UUID.randomUUID().toString());
+            jwtBuilder.claim(CLAIM_JWT_ID_SUBJECT, encryptedJwtId);
+        }
+
+        return jwtBuilder.compact();
 
     }
 
     public String createAccessToken(Long id, Role role, String name) {
-        return createToken(id, role, name, jwtProperties.getAccessExpirationTime());
+        return createToken(id, role, name, jwtProperties.getAccessExpirationTime(), true);
     }
 
     public String createRefreshToken(Long id, Role role, String name) {
-        return createToken(id, role, name, jwtProperties.getRefreshExpirationTime());
+        return createToken(id, role, name, jwtProperties.getRefreshExpirationTime(), false);
     }
 
     public boolean validateToken(String token) {
@@ -102,13 +113,18 @@ public class JwtProvider {
     }
 
     public Role getRole(String token) {
-        String encryptedRole = getClaims(token).get("role", String.class);
+        String encryptedRole = getClaims(token).get(CLAIM_ROLE_SUBJECT, String.class);
         return Role.valueOf(cipherService.decrypt(encryptedRole));
     }
 
     public String getName(String token){
-        String encryptedName = getClaims(token).get("name", String.class);
+        String encryptedName = getClaims(token).get(CLAIM_NAME_SUBJECT, String.class);
         return cipherService.decrypt(encryptedName);
+    }
+
+    public String getJwtId(String token){
+        String encryptedJwtId = getClaims(token).get(CLAIM_JWT_ID_SUBJECT, String.class);
+        return cipherService.decrypt(encryptedJwtId);
     }
 
     public LocalDateTime getTokenExpiration(String token) {

--- a/src/test/java/com/kefa/application/usecase/AuthenticationUseCaseTest.java
+++ b/src/test/java/com/kefa/application/usecase/AuthenticationUseCaseTest.java
@@ -69,7 +69,7 @@ class AuthenticationUseCaseTest {
     private AccountSignupRequest signupRequestDto;
     private AccountLoginRequest loginRequest;
     private RefreshToken refreshToken;
-    private String jwtId = "testJwtId";
+    private final String jwtId = "testJwtId";
 
 
 
@@ -193,12 +193,16 @@ class AuthenticationUseCaseTest {
         String accessToken = "accessToken";
         String refreshToken = "refreshToken";
         LocalDateTime expirationTime = LocalDateTime.now().plusDays(2);
+        String testJwtId = "testJwtId";
+
 
         when(accountRepository.findByEmailWithRefreshToken(loginRequest.getEmail())).thenReturn(Optional.of(account));
         when(passwordEncoder.matches(account.getPassword(), loginRequest.getPassword())).thenReturn(true);
         when(jwtProvider.createAccessToken(account.getId(), account.getRole(), account.getName())).thenReturn(accessToken);
         when(jwtProvider.createRefreshToken(account.getId(), account.getRole(), account.getName())).thenReturn(refreshToken);
         when(jwtProvider.getTokenExpiration(refreshToken)).thenReturn(expirationTime);
+        when(jwtProvider.getJwtId(accessToken)).thenReturn(testJwtId);
+
 
         // when
         TokenResponse response = authenticationUseCase.login(loginRequest);
@@ -212,6 +216,7 @@ class AuthenticationUseCaseTest {
                 savedToken.getAccount().getId().equals(account.getId()) &&
                 savedToken.getExpiresAt().equals(expirationTime)
         ));
+        verify(activeTokenRepository, times(1)).save(account.getId(), testJwtId);
     }
 
     @Test

--- a/src/test/java/com/kefa/application/usecase/AuthenticationUseCaseTest.java
+++ b/src/test/java/com/kefa/application/usecase/AuthenticationUseCaseTest.java
@@ -12,8 +12,11 @@ import com.kefa.common.exception.ErrorCode;
 import com.kefa.domain.entity.Account;
 import com.kefa.common.type.Role;
 import com.kefa.common.type.SubscriptionType;
+import com.kefa.domain.entity.RefreshToken;
 import com.kefa.domain.vo.AccountVO;
 import com.kefa.infrastructure.repository.AccountRepository;
+import com.kefa.infrastructure.repository.ActiveTokenRepository;
+import com.kefa.infrastructure.repository.BlackListRepository;
 import com.kefa.infrastructure.repository.RefreshTokenRepository;
 import com.kefa.infrastructure.security.jwt.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +55,12 @@ class AuthenticationUseCaseTest {
     @Mock
     private EmailVerificationUseCase emailVerificationUseCase;
 
+    @Mock
+    private ActiveTokenRepository activeTokenRepository;
+
+    @Mock
+    private BlackListRepository blackListRepository;
+
     @InjectMocks
     private AuthenticationUseCase authenticationUseCase;
 
@@ -59,6 +68,9 @@ class AuthenticationUseCaseTest {
     private final Long targetId = 1L;
     private AccountSignupRequest signupRequestDto;
     private AccountLoginRequest loginRequest;
+    private RefreshToken refreshToken;
+    private String jwtId = "testJwtId";
+
 
 
     @BeforeEach
@@ -82,6 +94,13 @@ class AuthenticationUseCaseTest {
             .email("test@test.com")
             .password("encodedPassword")
             .deviceId("device1")
+            .build();
+
+        refreshToken = RefreshToken.builder()
+            .id(10L)
+            .token("testRefreshToken")
+            .deviceId("testDevice1")
+            .expiresAt(LocalDateTime.now().plusDays(3))
             .build();
     }
 
@@ -196,7 +215,7 @@ class AuthenticationUseCaseTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 이메일로 로그인 실패")
+    @DisplayName("로그인 실패 - 존재하지 않는 이메일")
     void loginFailWhenEmailNotFound() {
 
         when(accountRepository.findByEmailWithRefreshToken(loginRequest.getEmail())).thenReturn(Optional.empty());
@@ -208,7 +227,7 @@ class AuthenticationUseCaseTest {
     }
 
     @Test
-    @DisplayName("비밀번호 다름으로 인한 로그인 실패")
+    @DisplayName("로그인 실패 - 비밀번호 다름")
     void loginFailWhenPasswordWrong() {
 
         when(accountRepository.findByEmailWithRefreshToken(loginRequest.getEmail())).thenReturn(Optional.of(account));
@@ -221,7 +240,7 @@ class AuthenticationUseCaseTest {
     }
 
     @Test
-    @DisplayName("이메일 미인증 계정으로 로그인 시도시 실패")
+    @DisplayName("로그인 실패 - 이메일 미인증 계정")
     void loginFailWhenAccountNotVerified() {
         // given
         Account account = Account.builder()
@@ -231,7 +250,7 @@ class AuthenticationUseCaseTest {
             .name("name")
             .subscriptionType(SubscriptionType.FREE)
             .role(Role.FREE_ACCOUNT)
-            .emailVerified(false)  // 미인증 계정
+            .emailVerified(false)
             .build();
 
         when(accountRepository.findByEmailWithRefreshToken(loginRequest.getEmail())).thenReturn(Optional.of(account));
@@ -244,7 +263,37 @@ class AuthenticationUseCaseTest {
     }
 
     @Test
-    @DisplayName("일반 회원가입 성공")
+    @DisplayName("로그아웃 성공 - 리프레시 토큰 존재")
+    void logoutSuccessWithRefreshToken() {
+        // given
+        account.addRefreshToken(refreshToken);
+        when(accountRepository.findByIdWithRefreshToken(account.getId())).thenReturn(Optional.of(account));
+        System.out.println("RefreshToken 연결 확인: " + account.getRefreshToken());
+
+
+        // when
+        authenticationUseCase.logout(account.getId(), jwtId);
+
+        // then
+        verify(refreshTokenRepository, times(1)).delete(refreshToken);
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공 - 리프레시 토큰 없음")
+    void logoutSuccessWithoutRefreshToken() {
+        // given
+        account.removeRefreshToken(refreshToken);
+        when(accountRepository.findByIdWithRefreshToken(account.getId())).thenReturn(Optional.of(account));
+
+        // when
+        authenticationUseCase.logout(account.getId(), jwtId);
+
+        // then
+        verify(refreshTokenRepository, never()).delete(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 성공")
     void signupSuccess() {
         // given
         Account account = signupRequestDto.toEntity("encodedPassword");
@@ -267,7 +316,7 @@ class AuthenticationUseCaseTest {
     }
 
     @Test
-    @DisplayName("중복 이메일로 인한 회원가입 실패")
+    @DisplayName("회원가입 실패 - 중복 이메일")
     void signupDuplicateEmailFailure() {
         // given
         when(accountRepository.existsByEmail(signupRequestDto.getEmail())).thenReturn(true);
@@ -279,7 +328,7 @@ class AuthenticationUseCaseTest {
     }
 
     @Test
-    @DisplayName("소셜 로그인 성공, 신규 사용자 계정 생성")
+    @DisplayName("소셜 로그인 성공 - 신규 사용자 계정 생성")
     void Oauth2JoinAndLoginSuccess() {
         // given
         Account newAccount = Account.builder()
@@ -308,7 +357,7 @@ class AuthenticationUseCaseTest {
     }
 
     @Test
-    @DisplayName("소셜 로그인 성공, 기존 사용자는 저장하지 않음")
+    @DisplayName("소셜 로그인 성공 - 기존 사용자")
     void Oauth2LoginSuccess() {
         // given
         Account existingAccount = Account.builder()

--- a/src/test/java/com/kefa/infrastructure/repository/ActiveTokenRepositoryTest.java
+++ b/src/test/java/com/kefa/infrastructure/repository/ActiveTokenRepositoryTest.java
@@ -1,0 +1,151 @@
+package com.kefa.infrastructure.repository;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ActiveTokenRepositoryTest {
+
+    private ActiveTokenRepository activeTokenRepository;
+    private Cache<Long, Set<String>> activeTokensCache;
+
+    private final Long accountId1 = 1L;
+    private final String jwtId1 = "testJwtId1";
+    private final String jwtId2 = "testJwtId2";
+
+    @BeforeEach
+    void setUp() {
+        activeTokensCache = Caffeine.newBuilder()
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .maximumSize(1000)
+            .build();
+
+        activeTokenRepository = new ActiveTokenRepository(activeTokensCache);
+    }
+
+    @Test
+    @DisplayName("새로운 accountId에 JWT ID 추가")
+    void saveNewAccountId() {
+        // when
+        activeTokenRepository.save(accountId1, jwtId1);
+
+        // then
+        Set<String> jwtIds = activeTokenRepository.findByAccountId(accountId1);
+
+        assertThat(jwtIds).isNotNull();
+        assertThat(jwtIds).containsExactly(jwtId1);
+        assertThat(activeTokensCache.asMap()).containsKey(accountId1);
+    }
+
+    @Test
+    @DisplayName("기존 accountId에 JWT ID 추가")
+    void saveExistingAccountId() {
+        // given
+        activeTokenRepository.save(accountId1, jwtId1);
+
+        // when
+        activeTokenRepository.save(accountId1, jwtId2);
+
+        // then
+        Set<String> jwtIds = activeTokenRepository.findByAccountId(accountId1);
+        assertThat(jwtIds).isNotNull();
+        assertThat(jwtIds).containsExactlyInAnyOrder(jwtId1, jwtId2);
+        assertThat(activeTokensCache.asMap()).containsKey(accountId1);
+    }
+
+    @Test
+    @DisplayName("특정 accountId의 특정 JWT ID 제거")
+    void deleteSpecificJwtId() {
+        // given
+        activeTokenRepository.save(accountId1, jwtId1);
+        activeTokenRepository.save(accountId1, jwtId2);
+
+        // when
+        activeTokenRepository.delete(accountId1, jwtId1);
+
+        // then
+        Set<String> jwtIds = activeTokenRepository.findByAccountId(accountId1);
+        assertThat(jwtIds).isNotNull();
+        assertThat(jwtIds).doesNotContain(jwtId1);
+        assertThat(jwtIds).containsExactly(jwtId2);
+        assertThat(activeTokensCache.asMap()).containsKey(accountId1);
+    }
+
+    @Test
+    @DisplayName("마지막 JWT ID 제거 시 accountId 캐시 데이터 제거")
+    void deleteLastJwtIdRemovesEntry() {
+        // given
+        activeTokenRepository.save(accountId1, jwtId1);
+
+        // when
+        activeTokenRepository.delete(accountId1, jwtId1);
+
+        // then
+        Set<String> jwtIds = activeTokensCache.getIfPresent(accountId1);
+        assertThat(jwtIds).isNull();
+        assertThat(activeTokensCache.asMap()).doesNotContainKey(accountId1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 accountId로 조회 시 빈 Set 반환")
+    void findByAccountIdNotFound() {
+        // when
+        Set<String> jwtIds = activeTokenRepository.findByAccountId(999L);
+
+        // then
+        assertThat(jwtIds).isNotNull();
+        assertThat(jwtIds).isEmpty();
+    }
+
+    @Test
+    @DisplayName("특정 accountId의 모든 JWT ID 제거")
+    void invalidateAccountAllActiveTokens() {
+        // given
+        activeTokenRepository.save(accountId1, jwtId1);
+        activeTokenRepository.save(accountId1, jwtId2);
+        Long accountId2 = 2L;
+        String jwtId3 = "testJwtId3";
+        activeTokenRepository.save(accountId2, jwtId3);
+
+        // when
+        activeTokenRepository.invalidateAccountAllActiveTokens(accountId1);
+
+        // then
+        Set<String> jwtIds1 = activeTokensCache.getIfPresent(accountId1);
+        assertThat(jwtIds1).isNull();
+        assertThat(activeTokensCache.asMap()).doesNotContainKey(accountId1);
+        Set<String> jwtIds2 = activeTokenRepository.findByAccountId(accountId2);
+        assertThat(jwtIds2).containsExactly(jwtId3);
+        assertThat(activeTokensCache.asMap()).containsKey(accountId2);
+    }
+
+    @Test
+    @DisplayName("캐시 만료 시간 테스트 (짧은 만료 시간)")
+    void cacheExpirationTest() throws InterruptedException {
+        // given
+        activeTokensCache = Caffeine.newBuilder()
+            .expireAfterWrite(100, TimeUnit.MILLISECONDS)
+            .maximumSize(100)
+            .build();
+        activeTokenRepository = new ActiveTokenRepository(activeTokensCache);
+
+        activeTokenRepository.save(accountId1, jwtId1);
+        assertThat(activeTokenRepository.findByAccountId(accountId1)).containsExactly(jwtId1);
+
+        // when
+        TimeUnit.MILLISECONDS.sleep(150);
+
+        // then
+        Set<String> jwtIds = activeTokensCache.getIfPresent(accountId1);
+        assertThat(jwtIds).isNull();
+        assertThat(activeTokensCache.asMap()).doesNotContainKey(accountId1);
+    }
+
+}

--- a/src/test/java/com/kefa/infrastructure/repository/BlackListRepositoryTest.java
+++ b/src/test/java/com/kefa/infrastructure/repository/BlackListRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.kefa.infrastructure.repository;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BlackListRepositoryTest {
+
+    private BlackListRepository blackListRepository;
+    private Cache<String, Boolean> blackListCache;
+
+    private final String jwtId1 = "testJwtId1";
+    private final String jwtId2 = "testJwtId2";
+
+    @BeforeEach
+    void setUp() {
+        blackListCache = Caffeine.newBuilder()
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .maximumSize(100)
+            .build();
+
+        blackListRepository = new BlackListRepository(blackListCache);
+    }
+
+    @Test
+    @DisplayName("단일 JWT ID를 블랙리스트에 추가")
+    void saveSingleJwtId() {
+        // when
+        blackListRepository.save(jwtId1);
+
+        // then
+        assertThat(blackListRepository.isBlacklisted(jwtId1)).isTrue();
+        assertThat(blackListCache.asMap()).containsKey(jwtId1);
+        assertThat(blackListCache.asMap().get(jwtId1)).isTrue();
+    }
+
+    @Test
+    @DisplayName("여러 JWT ID를 블랙리스트에 추가")
+    void saveAllJwtIds() {
+        // given
+        Set<String> jwtIdsToSave = new HashSet<>();
+        String jwtId3 = "testJwtId3";
+        String jwtId4 = "testJwtId4";
+
+        jwtIdsToSave.add(jwtId2);
+        jwtIdsToSave.add(jwtId3);
+
+        // when
+        blackListRepository.saveAll(jwtIdsToSave);
+
+        // then
+        assertThat(blackListRepository.isBlacklisted(jwtId2)).isTrue();
+        assertThat(blackListRepository.isBlacklisted(jwtId3)).isTrue();
+        assertThat(blackListRepository.isBlacklisted(jwtId4)).isFalse();
+        assertThat(blackListCache.asMap()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("블랙리스트에 없는 JWT ID 조회 시 false 반환")
+    void isBlacklistedReturnsFalseForNonExistent() {
+        // given
+        blackListRepository.save(jwtId1);
+
+        // when
+        boolean result = blackListRepository.isBlacklisted(jwtId2);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("캐시 만료 시간 테스트: 블랙리스트에 추가된 JWT ID가 만료 후 제거")
+    void cacheExpirationTest() throws InterruptedException {
+        // given
+        blackListCache = Caffeine.newBuilder()
+            .expireAfterWrite(100, TimeUnit.MILLISECONDS)
+            .maximumSize(10)
+            .build();
+        blackListRepository = new BlackListRepository(blackListCache);
+
+        blackListRepository.save(jwtId1);
+        assertThat(blackListRepository.isBlacklisted(jwtId1)).isTrue();
+
+        // when
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        // then
+        assertThat(blackListRepository.isBlacklisted(jwtId1)).isFalse();
+        assertThat(blackListCache.asMap()).doesNotContainKey(jwtId1);
+    }
+
+}

--- a/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/config/SecurityConfigTest.java
@@ -2,6 +2,7 @@ package com.kefa.infrastructure.security.config;
 
 import com.kefa.application.usecase.AccountUseCase;
 import com.kefa.application.usecase.AuthenticationUseCase;
+import com.kefa.infrastructure.repository.BlackListRepository;
 import com.kefa.infrastructure.security.auth.CustomOAuth2UserService;
 import com.kefa.infrastructure.security.auth.OAuth2SuccessHandler;
 import com.kefa.infrastructure.security.jwt.JwtProvider;
@@ -44,13 +45,20 @@ public class SecurityConfigTest {
     @MockBean
     private CustomOAuth2UserService customOAuth2UserService;
 
+    @MockBean
+    private BlackListRepository blackListRepository;
+
     @Test
     @DisplayName("공개 엔드포인트 접근 가능 성공")
     void publicEndpointsSuccessTest() throws Exception {
+        
         List<String> publicUrls = Arrays.asList(
             "/auth/login",
-            "/auth/join",
-            "/index"
+            "/auth/signup",
+            "/auth/email-verify",
+            "/auth/email-verify/resend",
+            "/auth/token/refresh",
+            "/oauth2/**"
         );
 
         for (String url : publicUrls) {

--- a/src/test/java/com/kefa/infrastructure/security/jwt/TokenResponseProviderTest.java
+++ b/src/test/java/com/kefa/infrastructure/security/jwt/TokenResponseProviderTest.java
@@ -75,6 +75,8 @@ public class TokenResponseProviderTest {
         assertThat(jwtProvider.validateToken(token)).isTrue();
         assertThat(jwtProvider.getId(token)).isEqualTo(id);
         assertThat(jwtProvider.getRole(token)).isEqualTo(role);
+        assertThat(jwtProvider.getName(token)).isEqualTo(name);
+        assertThat(jwtProvider.getJwtId(token)).isNotBlank();
     }
 
     @Test
@@ -93,10 +95,12 @@ public class TokenResponseProviderTest {
         assertThat(jwtProvider.validateToken(token)).isTrue();
         assertThat(jwtProvider.getId(token)).isEqualTo(id);
         assertThat(jwtProvider.getRole(token)).isEqualTo(role);
+        assertThat(jwtProvider.getName(token)).isEqualTo(name);
+        assertThat(jwtProvider.getJwtId(token)).isBlank();
     }
 
     @Test
-    @DisplayName("관리자 권한으로 토큰 생성 성공 테스트")
+    @DisplayName("관리자 권한으로 엑세스 토큰 생성 성공 테스트")
     void createTokenWithAdminRoleSuccess() {
         // given
         Long id = 1L;
@@ -109,10 +113,14 @@ public class TokenResponseProviderTest {
         // then
         assertThat(jwtProvider.getRole(token)).isEqualTo(Role.ADMIN);
         assertThat(jwtProvider.getRole(token).getRole()).isEqualTo("관리자");
+        assertThat(jwtProvider.getRole(token)).isEqualTo(role);
+        assertThat(jwtProvider.getName(token)).isEqualTo(name);
+        assertThat(jwtProvider.getJwtId(token)).isNotBlank();
+
     }
 
     @Test
-    @DisplayName("전문가 권한으로 토큰 생성 성공 테스트")
+    @DisplayName("전문가 권한으로 엑세스 토큰 생성 성공 테스트")
     void createTokenWithExpertRoleSuccess() {
         // given
         Long id = 1L;
@@ -125,10 +133,13 @@ public class TokenResponseProviderTest {
         // then
         assertThat(jwtProvider.getRole(token)).isEqualTo(Role.EXPERT);
         assertThat(jwtProvider.getRole(token).getRole()).isEqualTo("전문가");
+        assertThat(jwtProvider.getRole(token)).isEqualTo(role);
+        assertThat(jwtProvider.getName(token)).isEqualTo(name);
+        assertThat(jwtProvider.getJwtId(token)).isNotBlank();
     }
 
     @Test
-    @DisplayName("직원 권한으로 토큰 생성 성공 테스트")
+    @DisplayName("직원 권한으로 엑세스 토큰 생성 성공 테스트")
     void createTokenWithStaffRoleSuccess() {
         // given
         Long id = 1L;
@@ -141,6 +152,9 @@ public class TokenResponseProviderTest {
         // then
         assertThat(jwtProvider.getRole(token)).isEqualTo(Role.STAFF);
         assertThat(jwtProvider.getRole(token).getRole()).isEqualTo("직원");
+        assertThat(jwtProvider.getRole(token)).isEqualTo(role);
+        assertThat(jwtProvider.getName(token)).isEqualTo(name);
+        assertThat(jwtProvider.getJwtId(token)).isNotBlank();
     }
 
     @Test
@@ -195,6 +209,30 @@ public class TokenResponseProviderTest {
         // then
         assertThat(getRole).isEqualTo(role);
         assertThat(getRole.getRole()).isEqualTo("회원");
+    }
+
+    @Test
+    @DisplayName("토큰에서 Name 추출 성공 테스트")
+    void getNameSuccess() {
+        // given
+        String name = "test";
+        String token = jwtProvider.createAccessToken(1L, Role.FREE_ACCOUNT, "test");
+
+        // when
+        String getName = jwtProvider.getName(token);
+
+        // then
+        assertThat(getName).isEqualTo(name);
+    }
+
+    @Test
+    @DisplayName("토큰에서 JwtId 추출 성공 테스트")
+    void getJwtIdSuccess() {
+        // given
+        String token = jwtProvider.createAccessToken(1L, Role.FREE_ACCOUNT, "test");
+
+        // when & then
+        assertThat(jwtProvider.getJwtId(token)).isNotBlank();
     }
 
     @Test


### PR DESCRIPTION
## 💫 작업 내용

### 구현 기능
- JWT 기반 토큰 관리 및 로그아웃 기능


### 주요 변경사항
- JWT JTI(JWT ID) 도입: 액세스 토큰에 JTI를 포함하도록 JwtProvider를 개선하여 토큰의 고유 식별자 관리 기반을 마련했습니다. 리프레시 토큰에는 JTI를 포함하지 않도록 선택적 추가 로직을 구현했습니다.
- Caffeine 캐시 기반 토큰 관리
    - BlackListRepository를 통해 로그아웃된 액세스 토큰을 즉시 무효화
    - ActiveTokenRepository를 통해 사용자별 활성 액세스 토큰 목록을 관리
- 로그아웃 
    - 사용자 로그아웃 시 현재 사용 중인 액세스 토큰을 블랙리스트에 추가하고, 활성 토큰 목록에서 제거
    - 데이터베이스에 저장된 리프레시 토큰을 삭제
    - 요청시 블랙리스트에 등록된 토큰의 접근을 필터 단에서 즉시 차단하도록 구현
- Account 및 RefreshToken 엔티티 간 양방향 관계 설정/해제

## 🔍 테스트
- 로그아웃 기능에 대한 단위 테스트 추가, 리프레시 토큰 존재 여부에 따른 동작을 검증
- 로그인 성공 테스트에 ActiveTokenRepository 저장 검증 로직 추가
- ActiveTokenRepository와 BlackListRepository 테스트를 추가해 Caffeine 캐시 기반 토큰 관리 동작을 검증

## ✅ 체크리스트
- [x] 변경 사항에 대한 테스트를 진행했습니다