### PR TITLE
Chore: ActiveTokenCache를 Cache에서 LoadindCache로 변경

### DIFF
--- a/src/main/java/com/kefa/infrastructure/cache/CacheConfig.java
+++ b/src/main/java/com/kefa/infrastructure/cache/CacheConfig.java
@@ -2,11 +2,13 @@ package com.kefa.infrastructure.cache;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -24,11 +26,11 @@ public class CacheConfig {
     }
 
     @Bean
-    public Cache<Long, Set<String>> activeTokensCache() {
+    public LoadingCache<Long, Set<String>> activeTokensCache() {
         return Caffeine.newBuilder()
             .expireAfterWrite(accessExpirationTime, TimeUnit.MILLISECONDS)
             .maximumSize(100000L)
-            .build();
+            .build(key -> ConcurrentHashMap.newKeySet());
     }
 
     @Bean

--- a/src/main/java/com/kefa/infrastructure/repository/ActiveTokenRepository.java
+++ b/src/main/java/com/kefa/infrastructure/repository/ActiveTokenRepository.java
@@ -1,17 +1,16 @@
 package com.kefa.infrastructure.repository;
 
-import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 @RequiredArgsConstructor
 public class ActiveTokenRepository {
 
-    private final Cache<Long, Set<String>> activeTokensCache;
+    private final LoadingCache<Long, Set<String>> activeTokensCache;
 
     public void save(Long accountId, String jwtId) {
         findByAccountId(accountId).add(jwtId);
@@ -29,7 +28,7 @@ public class ActiveTokenRepository {
     }
 
     public Set<String> findByAccountId(Long accountId) {
-        return activeTokensCache.get(accountId, k -> ConcurrentHashMap.newKeySet());
+        return activeTokensCache.get(accountId);
     }
 
     public void invalidateAccountAllActiveTokens(Long accountId) {

--- a/src/test/java/com/kefa/infrastructure/repository/ActiveTokenRepositoryTest.java
+++ b/src/test/java/com/kefa/infrastructure/repository/ActiveTokenRepositoryTest.java
@@ -1,12 +1,13 @@
 package com.kefa.infrastructure.repository;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ActiveTokenRepositoryTest {
 
     private ActiveTokenRepository activeTokenRepository;
-    private Cache<Long, Set<String>> activeTokensCache;
+    private LoadingCache<Long, Set<String>> activeTokensCache;
 
     private final Long accountId1 = 1L;
     private final String jwtId1 = "testJwtId1";
@@ -25,7 +26,7 @@ public class ActiveTokenRepositoryTest {
         activeTokensCache = Caffeine.newBuilder()
             .expireAfterWrite(1, TimeUnit.HOURS)
             .maximumSize(1000)
-            .build();
+            .build(key -> ConcurrentHashMap.newKeySet());
 
         activeTokenRepository = new ActiveTokenRepository(activeTokensCache);
     }
@@ -133,7 +134,7 @@ public class ActiveTokenRepositoryTest {
         activeTokensCache = Caffeine.newBuilder()
             .expireAfterWrite(100, TimeUnit.MILLISECONDS)
             .maximumSize(100)
-            .build();
+            .build(key -> ConcurrentHashMap.newKeySet());
         activeTokenRepository = new ActiveTokenRepository(activeTokensCache);
 
         activeTokenRepository.save(accountId1, jwtId1);


### PR DESCRIPTION
## 💫 작업 내용
### 주요 변경사항

- ActiveTokenCache를 Cache에서 LoadingCache로 변경
  - 캐시 미스 시 자동으로 빈 Set을 로딩하도록 CacheLoader 등록
- 해당 변경에 따라 영향을 받는 테스트 코드 수정

## ✅ 체크리스트
- [x] 변경 사항에 대한 테스트를 진행했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 토큰 캐시가 누락된 키에 대해 자동으로 빈 집합을 초기화하도록 개선되었습니다.

* **테스트**
  * 캐시 동작 변경에 맞춰 테스트 코드가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->